### PR TITLE
Log and manage power controls of the charging pad

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ funclist
 nbproject/Makefile-*
 disassembly/
 *.map
+*.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "files.associations": {
-        "device_config.h": "c"
-    }
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "device_config.h": "c"
+    }
+}

--- a/error_checks.c
+++ b/error_checks.c
@@ -19,10 +19,7 @@
 
 
 bool check_battery_voltage_error(void){
-    uint16_t batt_curr = get_batt_curr_low_pass();
-
-    // get the un-scaled battery voltage (voltage divider)
-    uint16_t batt_voltage_mV = batt_curr * CURR_13V_RESISTOR;
+    uint16_t batt_voltage_mV = (uint16_t)(ADCC_GetSingleConversion(channel_BATT_VOLT)*BATT_RESISTANCE_DIVIDER);
 
     if (batt_voltage_mV < BATT_UNDERVOLTAGE_THRESHOLD_mV
             || batt_voltage_mV > BATT_OVERVOLTAGE_THRESHOLD_mV) {

--- a/error_checks.c
+++ b/error_checks.c
@@ -1,0 +1,88 @@
+#include "canlib/can.h"
+#include "canlib/can_common.h"
+#include "canlib/pic18f26k83/pic18f26k83_can.h"
+#include "canlib/pic18f26k83/pic18f26k83_timer.h"
+#include "canlib/message_types.h"
+#include "canlib/util/can_tx_buffer.h"
+
+#include "mcc_generated_files/fvr.h"
+#include "mcc_generated_files/adcc.h"
+
+#include "error_checks.h"
+#include "platform.h"
+
+#include <stdlib.h>
+
+//******************************************************************************
+//                              STATUS CHECKS                                 //
+//******************************************************************************
+
+
+bool check_battery_voltage_error(void){
+    uint16_t batt_curr = get_batt_curr_low_pass(); // weird double casting to uint16_t
+
+    // get the un-scaled battery voltage (voltage divider)
+    uint16_t batt_voltage_mV = batt_curr * CURR_13V_RESISTOR;
+
+    if (batt_voltage_mV < BATT_UNDERVOLTAGE_THRESHOLD_mV
+            || batt_voltage_mV > BATT_OVERVOLTAGE_THRESHOLD_mV) {
+
+        uint32_t timestamp = millis();
+        uint8_t batt_data[2] = {0};
+        batt_data[0] = (batt_voltage_mV >> 8) & 0xff;
+        batt_data[1] = (batt_voltage_mV >> 0) & 0xff;
+        enum BOARD_STATUS error_code = batt_voltage_mV < ACTUATOR_BATT_UNDERVOLTAGE_THRESHOLD_mV
+                ? E_BATT_UNDER_VOLTAGE
+                : E_BATT_OVER_VOLTAGE;
+
+        can_msg_t error_msg;
+        build_board_stat_msg(timestamp, error_code, batt_data, 2, &error_msg);
+        txb_enqueue(&error_msg);
+
+        // shit's bad yo
+        return false;
+    }
+    // things look ok
+    return true;
+}
+
+
+bool check_battery_current_error(void){
+    uint16_t curr_draw_mA = ADCC_GetSingleConversion(channel_POWER_V13) / CURR_13V_RESISTOR;
+
+    if (curr_draw_mA > BATT_OVERCURRENT_THRESHOLD_mA) {
+        uint32_t timestamp = millis();
+        uint8_t curr_data[2] = {0};
+        curr_data[0] = (curr_draw_mA >> 8) & 0xff;
+        curr_data[1] = (curr_draw_mA >> 0) & 0xff;
+
+        can_msg_t error_msg;
+        build_board_stat_msg(timestamp, E_BUS_OVER_CURRENT, curr_data, 2, &error_msg);
+        txb_enqueue(&error_msg);
+        return false;
+    }
+
+    // things look ok
+    return true;
+}
+
+
+bool check_bus_current_error(void){
+    uint16_t curr_draw_mA = ADCC_GetSingleConversion(channel_POWER_V5) / CURR_5V_RESISTOR;
+
+    if (curr_draw_mA > BUS_OVERCURRENT_THRESHOLD_mA) {
+        uint32_t timestamp = millis();
+        uint8_t curr_data[2] = {0};
+        curr_data[0] = (curr_draw_mA >> 8) & 0xff;
+        curr_data[1] = (curr_draw_mA >> 0) & 0xff;
+
+        can_msg_t error_msg;
+        build_board_stat_msg(timestamp, E_BUS_OVER_CURRENT, curr_data, 2, &error_msg);
+        txb_enqueue(&error_msg);
+        return false;
+    }
+
+    // things look ok
+    return true;
+}
+

--- a/error_checks.c
+++ b/error_checks.c
@@ -19,7 +19,7 @@
 
 
 bool check_battery_voltage_error(void){
-    uint16_t batt_curr = get_batt_curr_low_pass(); // weird double casting to uint16_t
+    uint16_t batt_curr = get_batt_curr_low_pass();
 
     // get the un-scaled battery voltage (voltage divider)
     uint16_t batt_voltage_mV = batt_curr * CURR_13V_RESISTOR;
@@ -31,7 +31,7 @@ bool check_battery_voltage_error(void){
         uint8_t batt_data[2] = {0};
         batt_data[0] = (batt_voltage_mV >> 8) & 0xff;
         batt_data[1] = (batt_voltage_mV >> 0) & 0xff;
-        enum BOARD_STATUS error_code = batt_voltage_mV < ACTUATOR_BATT_UNDERVOLTAGE_THRESHOLD_mV
+        enum BOARD_STATUS error_code = batt_voltage_mV < BATT_UNDERVOLTAGE_THRESHOLD_mV
                 ? E_BATT_UNDER_VOLTAGE
                 : E_BATT_OVER_VOLTAGE;
 

--- a/error_checks.h
+++ b/error_checks.h
@@ -1,0 +1,25 @@
+#ifndef ERROR_CHECKS_H
+#define	ERROR_CHECKS_H
+
+#include "canlib/message_types.h"
+
+#include <stdbool.h>
+
+// for voltages within these ranges, a warning will be sent out over CAN
+// values were determined by the given voltage rail range
+#define BATT_UNDERVOLTAGE_THRESHOLD_mV 9000
+#define BATT_OVERVOLTAGE_THRESHOLD_mV 12600
+
+// at this current, a warning will be sent out over CAN
+#define BATT_OVERCURRENT_THRESHOLD_mA 600 //TODO: CHECK VALUE WITH JACK
+
+// From bus line. At this current, a warning will be sent out over CAN
+#define BUS_OVERCURRENT_THRESHOLD_mA 300
+
+// General board status checkers
+bool check_battery_voltage_error(void);
+bool check_battery_current_error(void);
+bool check_bus_current_error(void);
+
+#endif	/* ERROR_CHECKS_H */
+

--- a/error_checks.h
+++ b/error_checks.h
@@ -11,10 +11,10 @@
 #define BATT_OVERVOLTAGE_THRESHOLD_mV 12600
 
 // at this current, a warning will be sent out over CAN
-#define BATT_OVERCURRENT_THRESHOLD_mA 600 //TODO: CHECK VALUE WITH JACK
+#define BATT_OVERCURRENT_THRESHOLD_mA 2000
 
 // From bus line. At this current, a warning will be sent out over CAN
-#define BUS_OVERCURRENT_THRESHOLD_mA 300
+#define BUS_OVERCURRENT_THRESHOLD_mA 500
 
 // General board status checkers
 bool check_battery_voltage_error(void);

--- a/main.c
+++ b/main.c
@@ -72,15 +72,15 @@ int main(void) {
             // Current draws
             can_msg_t power_13V_curr_msg;
             build_analog_data_msg(millis(),
-                                    SENSOR_BATT_CURR
+                                    SENSOR_BATT_CURR,
                                     (uint16_t)(ADCC_GetSingleConversion(channel_POWER_V13)*CURR13_DRAW_FACTOR),
                                     &power_13V_curr_msg);
             txb_enqueue(&power_13V_curr_msg);
 
             can_msg_t power_5V_curr_msg;
             build_analog_data_msg(millis(),
-                                    SENSOR_BUS_CURR
-                                    (uint16_t)(ADCC_GetSingleConversion(channel_POWER_V5)),
+                                    SENSOR_BUS_CURR,
+                                    (uint16_t)ADCC_GetSingleConversion(channel_POWER_V5),
                                     &power_5V_curr_msg);
             txb_enqueue(&power_5V_curr_msg);
 

--- a/main.c
+++ b/main.c
@@ -16,7 +16,7 @@ uint8_t tx_pool[100];
 
 int main(void) {
     // set up pins
-    gpio_init();
+    pin_init();
     
     // initialize mcc functions
     ADCC_Initialize();
@@ -61,13 +61,22 @@ int main(void) {
             heartbeat = !heartbeat;
             
             // We're alive, let's tell the world!
-            can_msg_t board_stat_msg;
-            // based off other examples (cansw_arming)
-            // just go and send all the can messages here
-            // making sure to txb_enqueue said message
-            // build_analog_data_msg(millis(), )
-            // build_board_stat_msg(millis(), E_NOMINAL, NULL, 0, &board_stat_msg);
-            txb_enqueue(&board_stat_msg);
+
+            //sends BATT voltage (3.2x BATT_VSENSE)
+            can_msg_t sensor_analog_battery_msg;
+            build_analog_data_msg(millis(), 
+                                    SENSOR_BATT_CURR, //not sure if this is correct enum, should be BATT_VSENSE?
+                                    (uint16_t)(ADCC_GetSingleConversion(channel_VSENSE)*ANALOG_SCALAR), //not sure if this is correct channel
+                                    &sensor_analog_batter_msg);
+            txb_enqueue(&sensor_analog_battery_msg);
+
+            //sends ground connected voltage (3.2x VSW_VSENSE)
+            can_msg_t sensor_analog_vsw_msg;
+            build_analog_data_msg(millis(), 
+                                    SENSOR_BUS_CURR, //not sure if this is correct enum, should be bus_VSENSE?
+                                    (uint16_t)(ADCC_GetSingleConversion(channel_VSENSE)*ANALOG_SCALAR), //not sure if this is correct channel
+                                    &sensor_analog_vsw_msg);     
+            txb_enqueue(&sensor_analog_vsw_msg);
         }
         //send any queued CAN messages
         txb_heartbeat();

--- a/main.c
+++ b/main.c
@@ -15,6 +15,10 @@ int main(void) {
     // set up pins
     gpio_init();
     
+    // initialize mcc functions
+    ADCC_Initialize();
+    FVR_Initialize();
+
     // intiialize the external oscillator
     oscillator_init();
 

--- a/main.c
+++ b/main.c
@@ -1,5 +1,5 @@
 #include <xc.h>
-#include "canlib.h" // TODO: I think this needs to be canlib/canlib.h, which means the _can and _timer can go
+#include "canlib.h"
 #include "canlib/can.h"
 #include "canlib/can_common.h"
 #include "canlib/pic18f26k83/pic18f26k83_can.h"

--- a/main.c
+++ b/main.c
@@ -1,3 +1,4 @@
+#include <xc.h>
 #include "canlib.h"
 #include "canlib/can.h"
 #include "canlib/can_common.h"
@@ -13,8 +14,6 @@
 #include "device_config.h"
 #include "platform.h"
 
-#include <xc.h>
-
 #define MAX_LOOP_TIME_DIFF_ms 250
 
 static void can_msg_handler(const can_msg_t *msg);
@@ -23,29 +22,24 @@ static void can_msg_handler(const can_msg_t *msg);
 uint8_t tx_pool[100];
 
 int main(void) {
-    // set up pins
-    pin_init();
-    
     // initialize mcc functions
     ADCC_Initialize();
     FVR_Initialize();
 
-    // intiialize the external oscillator
-    oscillator_init();
-
-    // init our millis() function
-    timer0_init();
+    pin_init(); // init pins
+    oscillator_init(); // init the external oscillator
+    timer0_init(); // init our millis() function
 
     // Enable global interrupts
     INTCON0bits.GIE = 1;
 
     // Set up CAN TX
-    TRISC0 = 0; // set as output
+    TRISC0 = 0;
     RC0PPS = 0x33; // make C0 transmit CAN TX (page 267)
 
     // Set up CAN RX
-    TRISC1 = 1; // set as input
-    ANSELC1 = 0; // not analog
+    TRISC1 = 1;
+    ANSELC1 = 0;
     CANRXPPS = 0x11; // make CAN read from C1 (page 264-265)
 
     // set up CAN module
@@ -68,19 +62,18 @@ int main(void) {
             BLUE_LED_SET(heartbeat);
             heartbeat = !heartbeat;
             
-            // We're alive, let's tell the world!
             // Current draws
             can_msg_t power_13V_curr_msg;
             build_analog_data_msg(millis(),
                                     SENSOR_BATT_CURR,
-                                    (uint16_t)(ADCC_GetSingleConversion(channel_POWER_V13)*CURR13_DRAW_FACTOR),
+                                    (uint16_t)(ADCC_GetSingleConversion(channel_POWER_V13)*CUR13_DRAW_FACTOR),
                                     &power_13V_curr_msg);
             txb_enqueue(&power_13V_curr_msg);
 
             can_msg_t power_5V_curr_msg;
             build_analog_data_msg(millis(),
                                     SENSOR_BUS_CURR,
-                                    (uint16_t)ADCC_GetSingleConversion(channel_POWER_V5),
+                                    (uint16_t)(ADCC_GetSingleConversion(channel_POWER_V5)*CUR5_DRAW_FACTOR),
                                     &power_5V_curr_msg);
             txb_enqueue(&power_5V_curr_msg);
 
@@ -88,7 +81,7 @@ int main(void) {
             can_msg_t batt_cur_msg;
             build_analog_data_msg(millis(),
                                     SENSOR_CHARGE_CURR,
-                                    (uint16_t)(ADCC_GetSingleConversion(channel_BATT_CURR)/BATT_CURR_FACTOR),
+                                    (uint16_t)(ADCC_GetSingleConversion(channel_BATT_CURR)/BATT_CUR_FACTOR),
                                     &batt_cur_msg);
             txb_enqueue(&batt_cur_msg);
 

--- a/main.c
+++ b/main.c
@@ -62,29 +62,28 @@ int main(void) {
             
             // We're alive, let's tell the world!
 
-            //sends battery charging voltage
-            can_msg_t sensor_analog_battery_charging_msg;
-            build_analog_data_msg(millis(), 
-                                    SENSOR_BATT_CURR, //not sure if this is correct enum, should be BATT_VSENSE?
-                                    (uint16_t)(ADCC_GetSingleConversion(channel_VSENSE)*ANALOG_SCALAR), //not sure if this is correct channel
-                                    &sensor_analog_battery_charging_msg);
-            txb_enqueue(&sensor_analog_battery_charging_msg);
+            // Battery charing current
+            can_msg_t batt_cur_msg;
+            build_analog_data_msg(millis(),
+                                    SENSOR_BATT_CURR,
+                                    (uint16_t)(ADCC_GetSingleConversion(channel_BATT_CURR)),
+                                    &batt_cur_msg);
+            txb_enqueue(&batt_cur_msg);
 
-            //sends BATT voltage (3.2x BATT_VSENSE)
-            can_msg_t sensor_analog_battery_msg;
-            build_analog_data_msg(millis(), 
-                                    SENSOR_BATT_CURR, //not sure if this is correct enum, should be BATT_VSENSE?
-                                    (uint16_t)(ADCC_GetSingleConversion(channel_VSENSE)*ANALOG_SCALAR*SCALE*3.2), //not sure if this is correct channel
-                                    &sensor_analog_batter_msg);
-            txb_enqueue(&sensor_analog_battery_msg);
+            // Voltage health messages
+            can_msg_t batt_volt_msg;
+            build_analog_data_msg(millis(),
+                                    SENSOR_BATT_CURR, //not sure if this is correct enum, is there BATT_VSENSE?
+                                    (uint16_t)(ADCC_GetSingleConversion(channel_BATT_VOLT)*RESISTANCE_FACTOR),
+                                    &batt_volt_msg);
+            txb_enqueue(&batt_volt_msg);
 
-            //sends ground connected voltage (3.2x VSW_VSENSE)
-            can_msg_t sensor_analog_vsw_msg;
-            build_analog_data_msg(millis(), 
-                                    SENSOR_BUS_CURR, //not sure if this is correct enum, should be bus_VSENSE?
-                                    (uint16_t)(ADCC_GetSingleConversion(channel_VSENSE)*ANALOG_SCALAR*SCALE*3.2), //not sure if this is correct channel
-                                    &sensor_analog_vsw_msg);
-            txb_enqueue(&sensor_analog_vsw_msg);
+            can_msg_t bus_volt_msg;
+            build_analog_data_msg(millis(),
+                                    SENSOR_BUS_CURR, //not sure if this is correct enum, is there BUS_VSENSE?
+                                    (uint16_t)(ADCC_GetSingleConversion(channel_CAN_VOLT)*RESISTANCE_FACTOR),
+                                    &bus_volt_msg);
+            txb_enqueue(&bus_volt_msg);
         }
         //send any queued CAN messages
         txb_heartbeat();

--- a/main.c
+++ b/main.c
@@ -62,11 +62,19 @@ int main(void) {
             
             // We're alive, let's tell the world!
 
+            //sends battery charging voltage
+            can_msg_t sensor_analog_battery_charging_msg;
+            build_analog_data_msg(millis(), 
+                                    SENSOR_BATT_CURR, //not sure if this is correct enum, should be BATT_VSENSE?
+                                    (uint16_t)(ADCC_GetSingleConversion(channel_VSENSE)*ANALOG_SCALAR), //not sure if this is correct channel
+                                    &sensor_analog_battery_charging_msg);
+            txb_enqueue(&sensor_analog_battery_charging_msg);
+
             //sends BATT voltage (3.2x BATT_VSENSE)
             can_msg_t sensor_analog_battery_msg;
             build_analog_data_msg(millis(), 
                                     SENSOR_BATT_CURR, //not sure if this is correct enum, should be BATT_VSENSE?
-                                    (uint16_t)(ADCC_GetSingleConversion(channel_VSENSE)*ANALOG_SCALAR*3.2), //not sure if this is correct channel
+                                    (uint16_t)(ADCC_GetSingleConversion(channel_VSENSE)*ANALOG_SCALAR*SCALE*3.2), //not sure if this is correct channel
                                     &sensor_analog_batter_msg);
             txb_enqueue(&sensor_analog_battery_msg);
 
@@ -74,8 +82,8 @@ int main(void) {
             can_msg_t sensor_analog_vsw_msg;
             build_analog_data_msg(millis(), 
                                     SENSOR_BUS_CURR, //not sure if this is correct enum, should be bus_VSENSE?
-                                    (uint16_t)(ADCC_GetSingleConversion(channel_VSENSE)*ANALOG_SCALAR*3.2), //not sure if this is correct channel
-                                    &sensor_analog_vsw_msg);     
+                                    (uint16_t)(ADCC_GetSingleConversion(channel_VSENSE)*ANALOG_SCALAR*SCALE*3.2), //not sure if this is correct channel
+                                    &sensor_analog_vsw_msg);
             txb_enqueue(&sensor_analog_vsw_msg);
         }
         //send any queued CAN messages

--- a/main.c
+++ b/main.c
@@ -72,7 +72,7 @@ int main(void) {
             // Current draws
             can_msg_t power_13V_curr_msg;
             build_analog_data_msg(millis(),
-                    SENSOR_BUS_CURR,
+                    SENSOR_ARM_BATT_1,
 //                                    SENSOR_13V_CURR, //these don't exist, but I think we need to create something
                                     (uint16_t)(ADCC_GetSingleConversion(channel_POWER_V13)*CURR13_DRAW_FACTOR),
                                     &power_13V_curr_msg);
@@ -80,7 +80,7 @@ int main(void) {
 
             can_msg_t power_5V_curr_msg;
             build_analog_data_msg(millis(),
-                    SENSOR_BUS_CURR,
+                    SENSOR_ARM_BATT_2,
 //                                    SENSOR_5V_CURR, //these don't exist, but I think we need to create something
                                     (uint16_t)(ADCC_GetSingleConversion(channel_POWER_V5)),
                                     &power_5V_curr_msg);
@@ -97,14 +97,14 @@ int main(void) {
             // Voltage health
             can_msg_t batt_volt_msg;
             build_analog_data_msg(millis(),
-                                    SENSOR_BATT_CURR, //not sure if this is correct enum, is there BATT_VSENSE?
+                                    SENSOR_MAG_1, //not sure if this is correct enum, is there BATT_VSENSE?
                                     (uint16_t)(ADCC_GetSingleConversion(channel_BATT_VOLT)*RESISTANCE_DIVIDER_FACTOR),
                                     &batt_volt_msg);
             txb_enqueue(&batt_volt_msg);
 
             can_msg_t bus_volt_msg;
             build_analog_data_msg(millis(),
-                                    SENSOR_BUS_CURR, //not sure if this is correct enum, is there BUS_VSENSE?
+                                    SENSOR_MAG_2, //not sure if this is correct enum, is there BUS_VSENSE?
                                     (uint16_t)(ADCC_GetSingleConversion(channel_CAN_VOLT)*RESISTANCE_DIVIDER_FACTOR),
                                     &bus_volt_msg);
             txb_enqueue(&bus_volt_msg);

--- a/main.c
+++ b/main.c
@@ -8,7 +8,6 @@
 #include "canlib/util/can_tx_buffer.h"
 #include "canlib/pic18f26k83/pic18f26k83_timer.h"
 
-// #include "mcc_generated_files/mcc.h"
 #include "mcc_generated_files/adcc.h"
 #include "mcc_generated_files/fvr.h"
 

--- a/main.c
+++ b/main.c
@@ -62,11 +62,16 @@ int main(void) {
             
             // We're alive, let's tell the world!
 
+            //figure out how to calculate the current scaling voltage (?)
+            // add CURR_5V
+
+            // add CURR_13V
+
             // Battery charing current
             can_msg_t batt_cur_msg;
             build_analog_data_msg(millis(),
                                     SENSOR_BATT_CURR,
-                                    (uint16_t)(ADCC_GetSingleConversion(channel_BATT_CURR)),
+                                    (uint16_t)(ADCC_GetSingleConversion(channel_BATT_CURR)), //not sure if any operations are needed on this
                                     &batt_cur_msg);
             txb_enqueue(&batt_cur_msg);
 

--- a/main.c
+++ b/main.c
@@ -13,6 +13,7 @@
 
 #include "device_config.h"
 #include "platform.h"
+#include "error_checks.h"
 
 static void can_msg_handler(const can_msg_t *msg);
 static void send_status_ok(void);
@@ -137,11 +138,9 @@ static void can_msg_handler(const can_msg_t *msg) {
             act_state = get_req_actuator_state(msg);
             if(act_id == ACTUATOR_CANBUS) {
                 if (act_state == ACTUATOR_ON) {
-                    // RED_LED_SET(true);
-                    CAN_5V_SET(true);
+                   CAN_5V_SET(true);
                 } else if (act_state == ACTUATOR_OFF) {
-                    // RED_LED_SET(false);
-                    CAN_5V_SET(false);
+                   CAN_5V_SET(false);
                 }
             } else if(act_id == ACTUATOR_CHARGE) {
                 if (act_state==ACTUATOR_ON) {

--- a/main.c
+++ b/main.c
@@ -51,7 +51,7 @@ int main(void) {
     uint32_t last_millis = millis();
     uint32_t sensor_last_millis = millis();
     
-    bool heartbeat = false;
+    bool heartbeat = false; //TODO: I think this needs to start true
     while (1) {
         if (millis() - last_millis > MAX_LOOP_TIME_DIFF_ms) {
             // update our loop counter

--- a/main.c
+++ b/main.c
@@ -66,7 +66,7 @@ int main(void) {
             can_msg_t sensor_analog_battery_msg;
             build_analog_data_msg(millis(), 
                                     SENSOR_BATT_CURR, //not sure if this is correct enum, should be BATT_VSENSE?
-                                    (uint16_t)(ADCC_GetSingleConversion(channel_VSENSE)*ANALOG_SCALAR), //not sure if this is correct channel
+                                    (uint16_t)(ADCC_GetSingleConversion(channel_VSENSE)*ANALOG_SCALAR*3.2), //not sure if this is correct channel
                                     &sensor_analog_batter_msg);
             txb_enqueue(&sensor_analog_battery_msg);
 
@@ -74,7 +74,7 @@ int main(void) {
             can_msg_t sensor_analog_vsw_msg;
             build_analog_data_msg(millis(), 
                                     SENSOR_BUS_CURR, //not sure if this is correct enum, should be bus_VSENSE?
-                                    (uint16_t)(ADCC_GetSingleConversion(channel_VSENSE)*ANALOG_SCALAR), //not sure if this is correct channel
+                                    (uint16_t)(ADCC_GetSingleConversion(channel_VSENSE)*ANALOG_SCALAR*3.2), //not sure if this is correct channel
                                     &sensor_analog_vsw_msg);     
             txb_enqueue(&sensor_analog_vsw_msg);
         }

--- a/main.c
+++ b/main.c
@@ -1,6 +1,14 @@
 #include <xc.h>
 #include "canlib.h"
+#include "canlib/can.h"
+#include "canlib/can_common.h"
+#include "canlib/pic18f26k83/pic18f26k83_can.h"
+#include "canlib/message_types.h"
+#include "canlib/util/timing_util.h"
+#include "canlib/util/can_tx_buffer.h"
+#include "canlib/pic18f26k83/pic18f26k83_timer.h"
 
+// #include "mcc_generated_files/mcc.h"
 #include "mcc_generated_files/adcc.h"
 #include "mcc_generated_files/fvr.h"
 
@@ -64,14 +72,16 @@ int main(void) {
             // Current draws
             can_msg_t power_13V_curr_msg;
             build_analog_data_msg(millis(),
-                                    SENSOR_13V_CURR, //these don't exist, but I think we need to create something
+                    SENSOR_BUS_CURR,
+//                                    SENSOR_13V_CURR, //these don't exist, but I think we need to create something
                                     (uint16_t)(ADCC_GetSingleConversion(channel_POWER_V13)*CURR13_DRAW_FACTOR),
                                     &power_13V_curr_msg);
             txb_enqueue(&power_13V_curr_msg);
 
             can_msg_t power_5V_curr_msg;
             build_analog_data_msg(millis(),
-                                    SENSOR_5V_CURR, //these don't exist, but I think we need to create something
+                    SENSOR_BUS_CURR,
+//                                    SENSOR_5V_CURR, //these don't exist, but I think we need to create something
                                     (uint16_t)(ADCC_GetSingleConversion(channel_POWER_V5)),
                                     &power_5V_curr_msg);
             txb_enqueue(&power_5V_curr_msg);
@@ -112,9 +122,10 @@ static void can_msg_handler(const can_msg_t *msg) {
         return;
     }
 
+    int act_state;
     switch (msg_type) {
         case MSG_ACTUATOR_CMD:
-            int act_state = get_req_actuator_state(msg)
+            act_state = get_req_actuator_state(msg);
             // jack said these actuator state constants might be renamed
             if (act_state==ACTUATOR_OPEN) {
                 LINE_5V_SET(true);

--- a/main.c
+++ b/main.c
@@ -1,4 +1,3 @@
-#include <xc.h>
 #include "canlib.h"
 #include "canlib/can.h"
 #include "canlib/can_common.h"
@@ -13,6 +12,8 @@
 
 #include "device_config.h"
 #include "platform.h"
+
+#include <xc.h>
 
 #define MAX_LOOP_TIME_DIFF_ms 250
 
@@ -71,16 +72,14 @@ int main(void) {
             // Current draws
             can_msg_t power_13V_curr_msg;
             build_analog_data_msg(millis(),
-                    SENSOR_ARM_BATT_1,
-//                                    SENSOR_13V_CURR, //these don't exist, but I think we need to create something
+                                    SENSOR_BATT_CURR
                                     (uint16_t)(ADCC_GetSingleConversion(channel_POWER_V13)*CURR13_DRAW_FACTOR),
                                     &power_13V_curr_msg);
             txb_enqueue(&power_13V_curr_msg);
 
             can_msg_t power_5V_curr_msg;
             build_analog_data_msg(millis(),
-                    SENSOR_ARM_BATT_2,
-//                                    SENSOR_5V_CURR, //these don't exist, but I think we need to create something
+                                    SENSOR_BUS_CURR
                                     (uint16_t)(ADCC_GetSingleConversion(channel_POWER_V5)),
                                     &power_5V_curr_msg);
             txb_enqueue(&power_5V_curr_msg);
@@ -88,25 +87,25 @@ int main(void) {
             // Battery charing current
             can_msg_t batt_cur_msg;
             build_analog_data_msg(millis(),
-                                    SENSOR_BATT_CURR,
+                                    SENSOR_CHARGE_CURR,
                                     (uint16_t)(ADCC_GetSingleConversion(channel_BATT_CURR)/BATT_CURR_FACTOR),
                                     &batt_cur_msg);
             txb_enqueue(&batt_cur_msg);
 
             // Voltage health
+            can_msg_t rocket_volt_msg;
+            build_analog_data_msg(millis(),
+                                    SENSOR_ROCKET_BATT,
+                                    (uint16_t)(ADCC_GetSingleConversion(channel_ROCKET_VOLT)*RESISTANCE_DIVIDER_FACTOR),
+                                    &rocket_volt_msg);
+            txb_enqueue(&rocket_volt_msg);
+
             can_msg_t batt_volt_msg;
             build_analog_data_msg(millis(),
-                                    SENSOR_MAG_1, //not sure if this is correct enum, is there BATT_VSENSE?
-                                    (uint16_t)(ADCC_GetSingleConversion(channel_BATT_VOLT)*RESISTANCE_DIVIDER_FACTOR),
+                                    SENSOR_CHARGE_VOLT,
+                                    (uint16_t)(ADCC_GetSingleConversion(channel_CAN_VOLT)*RESISTANCE_DIVIDER_FACTOR),
                                     &batt_volt_msg);
             txb_enqueue(&batt_volt_msg);
-
-            can_msg_t bus_volt_msg;
-            build_analog_data_msg(millis(),
-                                    SENSOR_MAG_2, //not sure if this is correct enum, is there BUS_VSENSE?
-                                    (uint16_t)(ADCC_GetSingleConversion(channel_CAN_VOLT)*RESISTANCE_DIVIDER_FACTOR),
-                                    &bus_volt_msg);
-            txb_enqueue(&bus_volt_msg);
         }
         //send any queued CAN messages
         txb_heartbeat();
@@ -125,7 +124,6 @@ static void can_msg_handler(const can_msg_t *msg) {
     switch (msg_type) {
         case MSG_ACTUATOR_CMD:
             act_state = get_req_actuator_state(msg);
-            // jack said these actuator state constants might be renamed
             if (act_state==ACTUATOR_OPEN) {
                 LINE_5V_SET(true);
             } else if (act_state==ACTUATOR_CLOSED) {

--- a/main.c
+++ b/main.c
@@ -1,6 +1,9 @@
 #include <xc.h>
 #include "canlib.h"
 
+#include "mcc_generated_files/adcc.h"
+#include "mcc_generated_files/fvr.h"
+
 #include "device_config.h"
 #include "platform.h"
 
@@ -59,7 +62,11 @@ int main(void) {
             
             // We're alive, let's tell the world!
             can_msg_t board_stat_msg;
-            build_board_stat_msg(millis(), E_NOMINAL, NULL, 0, &board_stat_msg);
+            // based off other examples (cansw_arming)
+            // just go and send all the can messages here
+            // making sure to txb_enqueue said message
+            // build_analog_data_msg(millis(), )
+            // build_board_stat_msg(millis(), E_NOMINAL, NULL, 0, &board_stat_msg);
             txb_enqueue(&board_stat_msg);
         }
         //send any queued CAN messages
@@ -76,16 +83,14 @@ static void can_msg_handler(const can_msg_t *msg) {
     }
 
     switch (msg_type) {
-        case MSG_LEDS_ON:
-            RED_LED_SET(1);
-            BLUE_LED_SET(1);
-            WHITE_LED_SET(1);
-            break;
-
-        case MSG_LEDS_OFF:
-            RED_LED_SET(0);
-            BLUE_LED_SET(0);
-            WHITE_LED_SET(0);
+        case MSG_ACTUATOR_CMD:
+            int act_state = get_req_actuator_state(msg)
+            // jack said these actuator states might change so yeah
+            if (act_state==ACTUATOR_OPEN) {
+                // turn on EN_5V
+            } else if (act_state==ACTUATOR_CLOSED) {
+                // turn off EN_5V
+            }
             break;
 
         // all the other ones - do nothing

--- a/mcc_generated_files/adcc.c
+++ b/mcc_generated_files/adcc.c
@@ -1,0 +1,301 @@
+/**
+  ADCC Generated Driver File
+
+  @Company
+    Microchip Technology Inc.
+
+  @File Name
+    adcc.c
+
+  @Summary
+    This is the generated driver implementation file for the ADCC driver using PIC10 / PIC12 / PIC16 / PIC18 MCUs
+
+  @Description
+    This source file provides implementations for driver APIs for ADCC.
+    Generation Information :
+        Product Revision  :  PIC10 / PIC12 / PIC16 / PIC18 MCUs - 1.65.2
+        Device            :  PIC18F26K83
+        Driver Version    :  2.01
+    The generated drivers are tested against the following:
+        Compiler          :  XC8 1.45
+        MPLAB             :  MPLAB X 4.15
+*/
+
+/*
+    (c) 2018 Microchip Technology Inc. and its subsidiaries. 
+    
+    Subject to your compliance with these terms, you may use Microchip software and any 
+    derivatives exclusively with Microchip products. It is your responsibility to comply with third party 
+    license terms applicable to your use of third party software (including open source software) that 
+    may accompany Microchip software.
+    
+    THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES, WHETHER 
+    EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE, INCLUDING ANY 
+    IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY, AND FITNESS 
+    FOR A PARTICULAR PURPOSE.
+    
+    IN NO EVENT WILL MICROCHIP BE LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, 
+    INCIDENTAL OR CONSEQUENTIAL LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND 
+    WHATSOEVER RELATED TO THE SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP 
+    HAS BEEN ADVISED OF THE POSSIBILITY OR THE DAMAGES ARE FORESEEABLE. TO 
+    THE FULLEST EXTENT ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL 
+    CLAIMS IN ANY WAY RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT 
+    OF FEES, IF ANY, THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS 
+    SOFTWARE.
+*/
+
+/**
+  Section: Included Files
+*/
+#include <xc.h>
+#include "adcc.h"
+
+/**
+  Section: ADCC Module Variables
+*/
+
+/**
+  Section: ADCC Module APIs
+*/
+
+void ADCC_Initialize(void)
+{
+    // set the ADCC to the options selected in the User Interface
+    // ADLTH 0; 
+    ADLTHL = 0x00;
+    // ADLTH 0; 
+    ADLTHH = 0x00;
+    // ADUTH 0; 
+    ADUTHL = 0x00;
+    // ADUTH 0; 
+    ADUTHH = 0x00;
+    // ADSTPT 0; 
+    ADSTPTL = 0x00;
+    // ADSTPT 0; 
+    ADSTPTH = 0x00;
+    // ADACC 0; 
+    ADACCU = 0x00;
+    // ADRPT 0; 
+    ADRPT = 0x00;
+    // ADPCH ANA0; 
+    ADPCH = 0x00;
+    // ADACQ 0; 
+    ADACQL = 0x00;
+    // ADACQ 0; 
+    ADACQH = 0x00;
+    // ADCAP Additional uC disabled; 
+    ADCAP = 0x00;
+    // ADPRE 0; 
+    ADPREL = 0x00;
+    // ADPRE 0; 
+    ADPREH = 0x00;
+    // ADDSEN disabled; ADGPOL digital_low; ADIPEN disabled; ADPPOL Vss; 
+    ADCON1 = 0x00;
+    // ADCRS 0; ADMD Basic_mode; ADACLR disabled; ADPSIS RES; 
+    ADCON2 = 0x00;
+    // ADCALC First derivative of Single measurement; ADTMD disabled; ADSOI ADGO not cleared; 
+    ADCON3 = 0x00;
+    // ADMATH registers not updated; 
+    ADSTAT = 0x00;
+    // ADNREF VSS; ADPREF FVR; 
+    ADREF = 0x03;
+    // ADACT disabled; 
+    ADACT = 0x00;
+    // ADCS FOSC/2; 
+    ADCLK = 0x00;
+    // ADGO stop; ADFM right; ADON enabled; ADCS FOSC/ADCLK; ADCONT disabled; 
+    ADCON0 = 0x84;
+    
+
+}
+
+void ADCC_StartConversion(adcc_channel_t channel)
+{
+    // select the A/D channel
+    ADPCH = channel;      
+  
+    // Turn on the ADC module
+    ADCON0bits.ADON = 1;
+
+    // Start the conversion
+    ADCON0bits.ADGO = 1;
+}
+
+bool ADCC_IsConversionDone()
+{
+    // Start the conversion
+    return ((unsigned char)(!ADCON0bits.ADGO));
+}
+
+adc_result_t ADCC_GetConversionResult(void)
+{
+    // Return the result
+    return ((adc_result_t)((ADRESH << 8) + ADRESL));
+}
+
+adc_result_t ADCC_GetSingleConversion(adcc_channel_t channel)
+{
+    // select the A/D channel
+    ADPCH = channel;  
+
+    // Turn on the ADC module
+    ADCON0bits.ADON = 1;
+	
+    //Disable the continuous mode.
+    ADCON0bits.ADCONT = 0;    
+
+    // Start the conversion
+    ADCON0bits.ADGO = 1;
+
+
+    // Wait for the conversion to finish
+    while (ADCON0bits.ADGO)
+    {
+    }
+    
+    
+    // Conversion finished, return the result
+    return ((adc_result_t)((ADRESH << 8) + ADRESL));
+}
+
+void ADCC_StopConversion(void)
+{
+    //Reset the ADGO bit.
+    ADCON0bits.ADGO = 0;
+}
+
+void ADCC_SetStopOnInterrupt(void)
+{
+    //Set the ADSOI bit.
+    ADCON3bits.ADSOI = 1;
+}
+
+void ADCC_DischargeSampleCapacitor(void)
+{
+    //Set the ADC channel to AVss.
+    ADPCH = 0x3C;   
+}
+
+void ADCC_LoadAcquisitionRegister(uint16_t acquisitionValue)
+{
+    //Load the ADACQH and ADACQL registers.
+    ADACQH = acquisitionValue >> 8; 
+    ADACQL = acquisitionValue;  
+}
+
+void ADCC_SetPrechargeTime(uint16_t prechargeTime)
+{
+    //Load the ADPREH and ADPREL registers.
+    ADPREH = prechargeTime >> 8;  
+    ADPREL = prechargeTime;
+}
+
+void ADCC_SetRepeatCount(uint8_t repeatCount)
+{
+    //Load the ADRPT register.
+    ADRPT = repeatCount;   
+}
+
+uint8_t ADCC_GetCurrentCountofConversions(void)
+{
+    //Return the contents of ADCNT register
+    return ADCNT;
+}
+
+void ADCC_ClearAccumulator(void)
+{
+    //Reset the ADCON2bits.ADACLR bit.
+    ADCON2bits.ADACLR = 1;
+}
+
+int24_t ADCC_GetAccumulatorValue(void)
+{
+    //Return the contents of ADACCU, ADACCH and ADACCL registers
+    return (((int24_t)ADACCU << 16)+((int24_t)ADACCH << 8) + ADACCL);
+}
+
+bool ADCC_HasAccumulatorOverflowed(void)
+{
+    //Return the status of ADSTATbits.ADAOV
+    return ADSTATbits.ADAOV;
+}
+
+uint16_t ADCC_GetFilterValue(void)
+{
+    //Return the contents of ADFLTRH and ADFLTRL registers
+    return ((uint16_t)((ADFLTRH << 8) + ADFLTRL));
+}
+
+uint16_t ADCC_GetPreviousResult(void)
+{
+    //Return the contents of ADPREVH and ADPREVL registers
+    return ((uint16_t)((ADPREVH << 8) + ADPREVL));
+}
+
+void ADCC_DefineSetPoint(uint16_t setPoint)
+{
+    //Sets the ADSTPTH and ADSTPTL registers
+    ADSTPTH = setPoint >> 8;
+    ADSTPTL = setPoint;
+}
+
+void ADCC_SetUpperThreshold(uint16_t upperThreshold)
+{
+    //Sets the ADUTHH and ADUTHL registers
+    ADUTHH = upperThreshold >> 8;
+    ADUTHL = upperThreshold;
+}
+
+void ADCC_SetLowerThreshold(uint16_t lowerThreshold)
+{
+    //Sets the ADLTHH and ADLTHL registers
+    ADLTHH = lowerThreshold >> 8;
+    ADLTHL = lowerThreshold;
+}
+
+uint16_t ADCC_GetErrorCalculation(void)
+{
+	//Return the contents of ADERRH and ADERRL registers
+	return ((uint16_t)((ADERRH << 8) + ADERRL));
+}
+
+void ADCC_EnableDoubleSampling(void)
+{
+    //Sets the ADCON1bits.ADDSEN
+    ADCON1bits.ADDSEN = 1;
+}
+
+void ADCC_EnableContinuousConversion(void)
+{
+    //Sets the ADCON0bits.ADCONT
+    ADCON0bits.ADCONT = 1;
+}
+
+void ADCC_DisableContinuousConversion(void)
+{
+    //Resets the ADCON0bits.ADCONT
+    ADCON0bits.ADCONT = 0;
+}
+
+bool ADCC_HasErrorCrossedUpperThreshold(void)
+{
+    //Returns the value of ADSTATbits.ADUTHR bit.
+    return ADSTATbits.ADUTHR;
+}
+
+bool ADCC_HasErrorCrossedLowerThreshold(void)
+{
+    //Returns the value of ADSTATbits.ADLTHR bit.
+    return ADSTATbits.ADLTHR;
+}
+
+uint8_t ADCC_GetConversionStageStatus(void)
+{
+    //Returns the contents of ADSTATbits.ADSTAT field.
+    return ADSTATbits.ADSTAT;
+}
+
+
+/**
+ End of File
+*/

--- a/mcc_generated_files/adcc.c
+++ b/mcc_generated_files/adcc.c
@@ -101,12 +101,10 @@ void ADCC_Initialize(void)
     ADREF = 0x03;
     // ADACT disabled; 
     ADACT = 0x00;
-    // ADCS FOSC/2; 
-    ADCLK = 0x00;
+    // ADCS FOSC/100; 
+    ADCLK = 0x31;
     // ADGO stop; ADFM right; ADON enabled; ADCS FOSC/ADCLK; ADCONT disabled; 
     ADCON0 = 0x84;
-    
-
 }
 
 void ADCC_StartConversion(adcc_channel_t channel)

--- a/mcc_generated_files/adcc.h
+++ b/mcc_generated_files/adcc.h
@@ -1,0 +1,785 @@
+/**
+  ADCC Generated Driver API Header File
+
+  @Company
+    Microchip Technology Inc.
+
+  @File Name
+    adcc.h
+
+  @Summary
+    This is the generated header file for the ADCC driver using PIC10 / PIC12 / PIC16 / PIC18 MCUs 
+
+  @Description
+    This header file provides APIs for driver for ADCC.
+    Generation Information :
+        Product Revision  :  PIC10 / PIC12 / PIC16 / PIC18 MCUs - 1.65.2
+        Device            :  PIC18F26K83
+        Driver Version    :  2.01
+    The generated drivers are tested against the following:
+        Compiler          :  XC8 1.45
+        MPLAB             :  MPLAB X 4.15
+*/
+
+/*
+    (c) 2018 Microchip Technology Inc. and its subsidiaries. 
+    
+    Subject to your compliance with these terms, you may use Microchip software and any 
+    derivatives exclusively with Microchip products. It is your responsibility to comply with third party 
+    license terms applicable to your use of third party software (including open source software) that 
+    may accompany Microchip software.
+    
+    THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES, WHETHER 
+    EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE, INCLUDING ANY 
+    IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY, AND FITNESS 
+    FOR A PARTICULAR PURPOSE.
+    
+    IN NO EVENT WILL MICROCHIP BE LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, 
+    INCIDENTAL OR CONSEQUENTIAL LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND 
+    WHATSOEVER RELATED TO THE SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP 
+    HAS BEEN ADVISED OF THE POSSIBILITY OR THE DAMAGES ARE FORESEEABLE. TO 
+    THE FULLEST EXTENT ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL 
+    CLAIMS IN ANY WAY RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT 
+    OF FEES, IF ANY, THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS 
+    SOFTWARE.
+*/
+
+#ifndef ADCC_H
+#define ADCC_H
+
+/**
+  Section: Included Files
+*/
+
+#include <xc.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus  // Provide C++ Compatibility
+
+    extern "C" {
+
+#endif
+
+/**
+  Section: Data Types Definitions
+*/
+
+/**
+ *  result size of an A/D conversion
+ */
+
+typedef uint16_t adc_result_t;
+#ifndef int24_t
+typedef signed short long int int24_t;
+#endif
+
+/** ADC Channel Definition
+
+ @Summary
+   Defines the channels available for conversion.
+
+ @Description
+   This routine defines the channels that are available for the module to use.
+
+ Remarks:
+   None
+ */
+
+typedef enum
+{
+    channel_VBAT =  0x0,
+    channel_VSENSE =  0x1,
+    channel_LINAC_POT =  0xD,
+    channel_VSS =  0x3B,
+    channel_Temp =  0x3C,
+    channel_DAC1 =  0x3D,
+    channel_FVR_Buffer1 =  0x3E,
+    channel_FVR_Buffer2 =  0x3F
+} adcc_channel_t;
+
+/**
+  Section: ADC Module APIs
+*/
+
+/**
+  @Summary
+    Initializes the ADCC
+
+  @Description
+    This routine initializes the Initializes the ADCC.
+    This routine must be called before any other ADCC routine is called.
+    This routine should only be called once during system initialization.
+
+  @Preconditions
+    None
+
+  @Param
+    None
+
+  @Returns
+    None
+
+  @Comment
+    
+
+  @Example
+    <code>
+    uint16_t convertedValue;    
+
+    ADCC_Initialize();
+    convertedValue = ADCC_GetSingleConversion(AN1_Channel);
+    </code>
+*/
+void ADCC_Initialize(void);
+
+/**
+  @Summary
+     Allows selection of a channel for conversion
+
+  @Description
+    This routine is used to select desired channel for conversion.
+    available
+    
+  @Preconditions
+    ADCC_Initialize() function should have been called before calling this function.
+
+  @Returns
+    None
+
+  @Param
+    Pass in required channel number
+    "For available channel refer to enum under adcc.h file"
+
+  @Example
+    <code>
+    uint16_t convertedValue; 
+
+    ADCC_Initialize();   
+    ADCC_StartConversion(AN1_Channel);
+    convertedValue = ADCC_GetConversionResult();
+    </code>
+*/
+void ADCC_StartConversion(adcc_channel_t channel);
+
+/**
+  @Summary
+    Returns true when the conversion is completed otherwise false.
+
+  @Description
+    This routine is used to determine if conversion is completed.
+    When conversion is complete routine returns true. It returns false otherwise.
+
+  @Preconditions
+    ADCC_Initialize() and ADCC_StartConversion(adcc_channel_t channel)
+    function should have been called before calling this function.
+
+  @Returns
+    true  - If conversion is complete
+    false - If conversion is not completed
+
+  @Param
+    None
+
+  @Example
+    <code>
+    uint16_t convertedValue;    
+
+    ADCC_Initialize();    
+    ADCC_StartConversion(AN1_Channel);
+    while(!ADCC_IsConversionDone());
+    convertedValue = ADCC_GetConversionResult();
+    </code>
+ */
+bool ADCC_IsConversionDone();
+
+/**
+  @Summary
+    Returns the ADCC conversion value.
+
+  @Description
+    This routine is used to get the analog to digital converted value. This
+    routine gets converted values from the channel specified.
+
+  @Preconditions
+    This routine returns the conversion value only after the conversion is complete.
+    Completion status can be checked using
+    ADCC_IsConversionDone() routine.
+
+  @Returns
+    Returns the converted value.
+
+  @Param
+    None
+
+  @Example
+    <code>
+    uint16_t convertedValue;    
+
+    ADCC_Initialize();    
+    ADCC_StartConversion(AN1_Channel);
+    while(!ADCC_IsConversionDone());
+    convertedValue = ADCC_GetConversionResult();
+    </code>
+ */
+adc_result_t ADCC_GetConversionResult(void);
+
+/**
+  @Summary
+    Returns the ADCC conversion value
+    also allows selection of a channel for conversion.
+
+  @Description
+    This routine is used to select desired channel for conversion
+    and to get the analog to digital converted value after a single conversion.
+
+  @Preconditions
+    ADCC_Initialize() and ADCC_DisableContinuousConversion() functions should have been called before calling this function.
+
+  @Returns
+    Returns the converted value.
+
+  @Param
+    Pass in required channel number.
+    "For available channel refer to enum under adcc.h file"
+
+  @Example
+    <code>
+    uint16_t convertedValue;
+
+    ADCC_Initialize();
+    ADCC_DisableContinuousConversion();
+	
+    convertedValue = ADCC_GetSingleConversion(AN1_Channel);
+    </code>
+*/
+adc_result_t ADCC_GetSingleConversion(adcc_channel_t channel);
+
+/**
+  @Summary
+    Stops the ADCC conversion by resetting the ADGO bit.
+
+  @Description
+    None
+
+  @Preconditions
+    ADCC_Initialize() and ADCC_StartConversion() functions should have been called before calling this function.
+
+  @Returns
+    None
+
+  @Param
+    None
+
+  @Example
+    <code>
+    ADCC_Initialize();
+	ADCC_StartConversion(AN1_Channel);
+	ADCC_StopConversion();
+    </code>
+*/
+void ADCC_StopConversion(void);
+
+/**
+  @Summary
+    Stops the ADCC from automatic retriggering in continuous sampling mode
+
+  @Description
+    None
+
+  @Preconditions
+    ADCC_Initialize() and ADCC_EnableContinuousConversion() functions should have been called before calling this function.
+
+  @Returns
+    None
+
+  @Param
+    None
+
+  @Example
+    <code>
+        ADCC_Initialize();
+	ADCC_EnableContinuousConversion();	
+    </code>
+*/
+void ADCC_SetStopOnInterrupt(void);
+
+/**
+  @Summary
+    Discharges the input sample capacitor by setting the channel to AVss.
+
+  @Description
+    None
+
+  @Preconditions
+    None.
+
+  @Returns
+    None
+
+  @Param
+    None
+
+  @Example
+    <code>
+    </code>
+*/
+void ADCC_DischargeSampleCapacitor(void); 
+
+/**
+  @Summary
+    Loads the ADACQ register by the 8 bit value sent as argument.
+
+  @Description
+    None
+
+  @Preconditions
+    None.
+
+  @Returns
+    None
+
+  @Param
+    8 bit value to be set in the acquisition register.
+
+  @Example
+    <code>
+        uint16_t acquisitionValue = 98;
+	ADCC_LoadAcquisitionRegister(acquisitionValue);
+    </code>
+*/
+void ADCC_LoadAcquisitionRegister(uint16_t);
+/**
+  @Summary
+    Loads the ADPRE register by the 8 bit value sent as argument.
+
+  @Description
+    None
+
+  @Preconditions
+    None.
+
+  @Returns
+    None
+
+  @Param
+    8 bit value to be set in the precharge register.
+
+  @Example
+    <code>
+        uint16_t prechargeTime = 98;
+	ADCC_SetPrechargeTime(prechargeTime);
+    </code>
+*/
+void ADCC_SetPrechargeTime(uint16_t);
+
+/**
+  @Summary
+    Loads the ADRPT register by the 8 bit value sent as argument.
+
+  @Description
+    None
+
+  @Preconditions
+    None.
+
+  @Returns
+    None
+
+  @Param
+    8 bit value to be set in the Repeat register.
+
+  @Example
+    <code>
+	uint8_t repeat = 98;
+	ADCC_SetRepeatCount(repeat);
+    </code>
+*/
+void ADCC_SetRepeatCount(uint8_t);
+
+/**
+  @Summary
+    Returns the ADCNT register contents.
+
+  @Description
+    None
+
+  @Preconditions
+    None.
+
+  @Returns
+    Contents of ADCNT register
+
+  @Param
+    None.
+
+  @Example
+    <code>
+	uint8_t count = ADCC_GetCurrentCountofConversions();
+	
+    </code>
+*/
+uint8_t ADCC_GetCurrentCountofConversions(void);
+
+/**
+  @Summary
+    Clears the ADACLR bit.
+
+  @Description
+    None
+
+  @Preconditions
+    None.
+
+  @Returns
+    None
+
+  @Param
+    None.
+
+  @Example
+    <code>
+	ADCC_ClearAccumulator();
+	
+    </code>
+*/
+void ADCC_ClearAccumulator(void);
+
+/**
+  @Summary
+   Returns the value obtained from ADACCU, ADACCH and ADACCL registers.
+
+  @Description
+    None
+
+  @Preconditions
+    None.
+
+  @Returns
+    Value obtained from ADACCU, ADACCH and ADACCL registers.
+
+  @Param
+    None.
+
+  @Example
+    <code>
+        uint32_t accumulatorValue = ADCC_GetAccumulatorValue();
+    </code>
+*/
+int24_t ADCC_GetAccumulatorValue(void);
+
+/**
+  @Summary
+   Returns the contents of ADAOV setting.
+
+  @Description
+    None
+
+  @Preconditions
+    None.
+
+  @Returns
+    Value of ADAOV bit.
+
+  @Param
+    None.
+
+  @Example
+    <code>
+	bool accumulatorOverflow = ADCC_HasAccumulatorOverflowed();
+	
+    </code>
+*/
+bool ADCC_HasAccumulatorOverflowed(void);
+
+/**
+  @Summary
+   Returns the contents of ADFLTRH and ADFLTRL registers.
+
+  @Description
+    None
+
+  @Preconditions
+    None.
+
+  @Returns
+    16 bit value obtained from ADFLTRH and ADFLTRL registers.
+
+  @Param
+    None.
+
+  @Example
+    <code>
+	uint16_t filterValue = ADCC_GetFilterValue();
+	
+    </code>
+*/
+uint16_t ADCC_GetFilterValue(void);
+
+/**
+  @Summary
+   Returns the contents of ADPREVH and ADPREVL registers.
+
+  @Description
+    None
+
+  @Preconditions
+    None.
+
+  @Returns
+    16 bit value obtained from ADPREVH and ADPREVL registers.
+
+  @Param
+    None.
+
+  @Example
+    <code>
+	uint16_t prevResult = ADCC_GetPreviousResult();
+	
+    </code>
+*/
+uint16_t ADCC_GetPreviousResult(void);
+
+/**
+  @Summary
+   Sets the ADSTPTH and ADSTPTL registers.
+
+  @Description
+    None
+
+  @Preconditions
+    None
+
+  @Returns
+    None
+
+  @Param
+    16 bit value for set point.
+
+  @Example
+    <code>
+	uint16_t setPoint = 90;
+	ADCC_DefineSetPoint(setPoint);
+    </code>
+*/
+void ADCC_DefineSetPoint(uint16_t);
+
+/**
+  @Summary
+   Sets the ADUTHH and ADUTHL register.
+
+  @Description
+    None
+
+  @Preconditions
+    None
+
+  @Returns
+    None
+
+  @Param
+    16 bit value for upper threshold.
+
+  @Example
+    <code>
+	uint16_t upperThreshold = 90;
+	ADCC_SetUpperThreshold(upperThreshold);
+	
+    </code>
+*/
+void ADCC_SetUpperThreshold(uint16_t);
+
+/**
+  @Summary
+   Sets the ADLTHH and ADLTHL register.
+
+  @Description
+    None
+
+  @Preconditions
+    None
+
+  @Returns
+    None
+
+  @Param
+    16 bit value for lower threshold..
+
+  @Example
+    <code>
+	uint16_t lowerThreshold = 90;
+	ADCC_SetLowerThreshold(lowerThreshold);
+	
+    </code>
+*/
+void ADCC_SetLowerThreshold(uint16_t);
+
+/**
+  @Summary
+   Returns the 16 bit value obtained from ADERRH and ADERRL registers.
+
+  @Description
+    None
+
+  @Preconditions
+    None
+
+  @Returns
+    16 bit value obtained from ADERRH and ADERRL registers.
+
+  @Param
+    None.
+
+  @Example
+    <code>
+	uint16_t error = ADCC_GetErrorCalculation(void);
+    </code>
+*/
+uint16_t ADCC_GetErrorCalculation(void);
+
+/**
+  @Summary
+   Sets the ADDSEN bit.
+
+  @Description
+    None
+
+  @Preconditions
+    None
+
+  @Returns
+    None
+
+  @Param
+    None.
+
+  @Example
+    <code>
+    </code>
+*/
+void ADCC_EnableDoubleSampling(void);
+
+/**
+  @Summary
+   Sets the ADCONT bit.
+
+  @Description
+    None
+
+  @Preconditions
+    None
+
+  @Returns
+    None
+
+  @Param
+    None.
+
+  @Example
+    <code>
+    </code>
+*/
+void ADCC_EnableContinuousConversion(void);
+
+/**
+  @Summary
+   Resets the ADCONT bit.
+
+  @Description
+    None
+
+  @Preconditions
+    None
+
+  @Returns
+    None
+
+  @Param
+    None.
+
+  @Example
+    <code>
+    </code>
+*/
+void ADCC_DisableContinuousConversion(void);
+
+/**
+  @Summary
+   Returns the value of ADUTHR bit.
+
+  @Description
+    None
+
+  @Preconditions
+    None
+
+  @Returns
+    Returns the value of ADUTHR bit.
+
+  @Param
+    None.
+
+  @Example
+    <code>
+    </code>
+*/
+bool ADCC_HasErrorCrossedUpperThreshold(void);
+
+/**
+  @Summary
+   Returns the value of ADLTHR bit.
+
+  @Description
+    None
+
+  @Preconditions
+    None
+
+  @Returns
+    Returns the value of ADLTHR bit.
+
+  @Param
+    None.
+
+  @Example
+    <code>
+    </code>
+*/
+bool ADCC_HasErrorCrossedLowerThreshold(void);
+
+/**
+  @Summary
+   Returns value of ADSTAT setting.
+
+  @Description
+    None
+
+  @Preconditions
+    None
+
+  @Returns
+    Returns value of ADSTAT setting.
+
+  @Param
+    None.
+
+  @Example
+    <code>
+    </code>
+*/
+uint8_t ADCC_GetConversionStageStatus(void);
+
+
+
+
+#ifdef __cplusplus  // Provide C++ Compatibility
+
+    }
+
+#endif
+
+#endif	//ADCC_H
+/**
+ End of File
+*/
+

--- a/mcc_generated_files/adcc.h
+++ b/mcc_generated_files/adcc.h
@@ -86,6 +86,7 @@ typedef signed short long int int24_t;
    None
  */
 
+// need to rename these based on the datasheet (go read later)
 typedef enum
 {
     channel_VBAT =  0x0,

--- a/mcc_generated_files/adcc.h
+++ b/mcc_generated_files/adcc.h
@@ -92,7 +92,7 @@ typedef enum
     channel_POWER_V13 = 0x0,
     channel_POWER_V5  = 0x1,
     channel_BATT_CURR = 0x4,
-    channel_BATT_VOLT = 0x12,
+    channel_ROCKET_VOLT = 0x12,
     channel_CAN_VOLT  = 0x13
 } adcc_channel_t; //page 677
 

--- a/mcc_generated_files/adcc.h
+++ b/mcc_generated_files/adcc.h
@@ -86,8 +86,7 @@ typedef signed short long int int24_t;
    None
  */
 
-typedef enum
-{
+typedef enum {
     channel_POWER_V13 = 0x0,
     channel_POWER_V5  = 0x1,
     channel_BATT_CURR = 0x4,

--- a/mcc_generated_files/adcc.h
+++ b/mcc_generated_files/adcc.h
@@ -86,7 +86,6 @@ typedef signed short long int int24_t;
    None
  */
 
-// need to rename these based on the datasheet (go read later)
 typedef enum
 {
     channel_POWER_V13 = 0x0,

--- a/mcc_generated_files/adcc.h
+++ b/mcc_generated_files/adcc.h
@@ -89,9 +89,9 @@ typedef signed short long int int24_t;
 typedef enum {
     channel_POWER_V13 = 0x0,
     channel_POWER_V5  = 0x1,
-    channel_BATT_CURR = 0x4,
-    channel_ROCKET_VOLT = 0x12,
-    channel_CAN_VOLT  = 0x13
+    channel_CHARGE_CURR = 0x4,
+    channel_BATT_VOLT = 0x12,
+    channel_GROUND_VOLT  = 0x13
 } adcc_channel_t; //page 677
 
 /**

--- a/mcc_generated_files/adcc.h
+++ b/mcc_generated_files/adcc.h
@@ -89,15 +89,12 @@ typedef signed short long int int24_t;
 // need to rename these based on the datasheet (go read later)
 typedef enum
 {
-    channel_VBAT =  0x0,
-    channel_VSENSE =  0x1,
-    channel_LINAC_POT =  0xD,
-    channel_VSS =  0x3B,
-    channel_Temp =  0x3C,
-    channel_DAC1 =  0x3D,
-    channel_FVR_Buffer1 =  0x3E,
-    channel_FVR_Buffer2 =  0x3F
-} adcc_channel_t;
+    channel_POWER_V13 = 0x0,
+    channel_POWER_V5  = 0x1,
+    channel_BATT_CURR = 0x4,
+    channel_BATT_VOLT = 0x12,
+    channel_CAN_VOLT  = 0x13
+} adcc_channel_t; //page 677
 
 /**
   Section: ADC Module APIs

--- a/mcc_generated_files/fvr.c
+++ b/mcc_generated_files/fvr.c
@@ -1,0 +1,71 @@
+/**
+  FVR Generated Driver File
+
+  @Company
+    Microchip Technology Inc.
+
+  @File Name
+    fvr.c
+
+  @Summary
+    This is the generated driver implementation file for the FVR driver using PIC10 / PIC12 / PIC16 / PIC18 MCUs
+
+  @Description
+    This source file provides APIs for FVR.
+    Generation Information :
+        Product Revision  :  PIC10 / PIC12 / PIC16 / PIC18 MCUs - 1.65.2
+        Device            :  PIC18F26K83
+        Driver Version    :  2.01
+    The generated drivers are tested against the following:
+        Compiler          :  XC8 1.45
+        MPLAB             :  MPLAB X 4.15
+*/
+
+/*
+    (c) 2018 Microchip Technology Inc. and its subsidiaries. 
+    
+    Subject to your compliance with these terms, you may use Microchip software and any 
+    derivatives exclusively with Microchip products. It is your responsibility to comply with third party 
+    license terms applicable to your use of third party software (including open source software) that 
+    may accompany Microchip software.
+    
+    THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES, WHETHER 
+    EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE, INCLUDING ANY 
+    IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY, AND FITNESS 
+    FOR A PARTICULAR PURPOSE.
+    
+    IN NO EVENT WILL MICROCHIP BE LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, 
+    INCIDENTAL OR CONSEQUENTIAL LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND 
+    WHATSOEVER RELATED TO THE SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP 
+    HAS BEEN ADVISED OF THE POSSIBILITY OR THE DAMAGES ARE FORESEEABLE. TO 
+    THE FULLEST EXTENT ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL 
+    CLAIMS IN ANY WAY RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT 
+    OF FEES, IF ANY, THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS 
+    SOFTWARE.
+*/
+
+/**
+  Section: Included Files
+*/
+
+#include <xc.h>
+#include "fvr.h"
+
+/**
+  Section: FVR APIs
+*/
+
+void FVR_Initialize(void)
+{
+    // CDAFVR off; FVREN enabled; TSRNG Lo_range; ADFVR 4x; TSEN disabled; 
+    FVRCON = 0x83;
+}
+
+bool FVR_IsOutputReady(void)
+{
+    return (FVRCONbits.FVRRDY);
+}
+/**
+ End of File
+*/
+

--- a/mcc_generated_files/fvr.h
+++ b/mcc_generated_files/fvr.h
@@ -1,0 +1,139 @@
+/**
+  FVR Generated Driver API Header File
+
+  @Company
+    Microchip Technology Inc.
+
+  @File Name
+    fvr.h
+
+  @Summary
+    This is the generated header file for the FVR driver using PIC10 / PIC12 / PIC16 / PIC18 MCUs
+
+  @Description
+    This header file provides APIs for driver for FVR.
+    Generation Information :
+        Product Revision  :  PIC10 / PIC12 / PIC16 / PIC18 MCUs - 1.65.2
+        Device            :  PIC18F26K83
+        Driver Version    :  2.01
+    The generated drivers are tested against the following:
+        Compiler          :  XC8 1.45
+        MPLAB 	          :  MPLAB X 4.15
+*/
+
+/*
+    (c) 2018 Microchip Technology Inc. and its subsidiaries. 
+    
+    Subject to your compliance with these terms, you may use Microchip software and any 
+    derivatives exclusively with Microchip products. It is your responsibility to comply with third party 
+    license terms applicable to your use of third party software (including open source software) that 
+    may accompany Microchip software.
+    
+    THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES, WHETHER 
+    EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE, INCLUDING ANY 
+    IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY, AND FITNESS 
+    FOR A PARTICULAR PURPOSE.
+    
+    IN NO EVENT WILL MICROCHIP BE LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, 
+    INCIDENTAL OR CONSEQUENTIAL LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND 
+    WHATSOEVER RELATED TO THE SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP 
+    HAS BEEN ADVISED OF THE POSSIBILITY OR THE DAMAGES ARE FORESEEABLE. TO 
+    THE FULLEST EXTENT ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL 
+    CLAIMS IN ANY WAY RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT 
+    OF FEES, IF ANY, THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS 
+    SOFTWARE.
+*/
+
+#ifndef FVR_H
+#define FVR_H
+
+/**
+  Section: Included Files
+*/
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus  // Provide C++ Compatibility
+
+    extern "C" {
+
+#endif
+
+/**
+  Section: FVR APIs
+*/
+
+/**
+  @Summary
+    Initializes the FVR
+
+  @Description
+    This routine initializes the FVR.
+    This routine must be called before any other FVR routine is called.
+    This routine should only be called once during system initialization.
+
+  @Preconditions
+    None
+
+  @Param
+    None
+
+  @Returns
+    None
+
+  @Comment
+    
+
+  @Example
+    <code>
+    FVR_Initialize();
+    </code>
+*/
+ void FVR_Initialize(void);
+
+/**
+  @Summary
+    Gets the FVR output ready status.
+
+  @Description
+    This routine gets the FVR output ready status.
+
+  @Preconditions
+    The FVR_Initialize() routine should be called
+    prior to use this routine.
+
+  @Param
+    None
+
+  @Returns
+     true  - FVR module is ready for use.
+     false - FVR module is not ready for use.
+
+  @Example
+    <code>
+    FVR_Initialize();
+
+    if(FVR_IsOutputReady())
+    {
+          //user code
+    }
+    else
+    {
+          //user code
+    }
+    </code>
+*/
+bool FVR_IsOutputReady(void);
+
+#ifdef __cplusplus  // Provide C++ Compatibility
+
+    }
+
+#endif
+
+#endif // FVR_H
+/**
+ End of File
+*/
+

--- a/nbproject/configurations.xml
+++ b/nbproject/configurations.xml
@@ -198,6 +198,7 @@
         <property key="debugoptions.debug-startup" value="Use system settings"/>
         <property key="debugoptions.reset-behaviour" value="Use system settings"/>
         <property key="debugoptions.useswbreakpoints" value="false"/>
+        <property key="firmware.download.all" value="false"/>
         <property key="hwtoolclock.frcindebug" value="false"/>
         <property key="memories.aux" value="false"/>
         <property key="memories.bootflash" value="true"/>

--- a/nbproject/configurations.xml
+++ b/nbproject/configurations.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configurationDescriptor version="65">
   <logicalFolder name="root" displayName="root" projectFiles="true">
+    <logicalFolder name="canlib" displayName="canlib" projectFiles="true">
+    </logicalFolder>
     <logicalFolder name="HeaderFiles"
                    displayName="Header Files"
                    projectFiles="true">
@@ -67,6 +69,9 @@
       <itemPath>Makefile</itemPath>
     </logicalFolder>
   </logicalFolder>
+  <sourceRootList>
+    <Elem>canlib</Elem>
+  </sourceRootList>
   <projectmakefile>Makefile</projectmakefile>
   <confs>
     <conf name="default" type="2">
@@ -77,8 +82,8 @@
         <targetPluginBoard></targetPluginBoard>
         <platformTool>PICkit3PlatformTool</platformTool>
         <languageToolchain>XC8</languageToolchain>
-        <languageToolchainVersion>2.41</languageToolchainVersion>
-        <platform>4</platform>
+        <languageToolchainVersion>2.31</languageToolchainVersion>
+        <platform>2</platform>
       </toolsSet>
       <packs>
         <pack name="PIC18F-K_DFP" vendor="Microchip" version="1.5.114"/>
@@ -116,7 +121,7 @@
         <property key="call-prologues" value="false"/>
         <property key="default-bitfield-type" value="true"/>
         <property key="default-char-type" value="true"/>
-        <property key="define-macros" value="BOARD_UNIQUE_ID=0"/>
+        <property key="define-macros" value="BOARD_UNIQUE_ID=BOARD_ID_CHARGING"/>
         <property key="disable-optimizations" value="true"/>
         <property key="extra-include-directories" value="canlib;mcc_generated_files"/>
         <property key="favor-optimization-for" value="-speed,+space"/>
@@ -200,7 +205,6 @@
         <property key="debugoptions.debug-startup" value="Use system settings"/>
         <property key="debugoptions.reset-behaviour" value="Use system settings"/>
         <property key="debugoptions.useswbreakpoints" value="false"/>
-        <property key="firmware.download.all" value="false"/>
         <property key="hwtoolclock.frcindebug" value="false"/>
         <property key="memories.aux" value="false"/>
         <property key="memories.bootflash" value="true"/>
@@ -286,15 +290,12 @@
       </XC8-CO>
       <XC8-config-global>
         <property key="advanced-elf" value="true"/>
-        <property key="constdata-progmem" value="true"/>
         <property key="gcc-opt-driver-new" value="true"/>
         <property key="gcc-opt-std" value="-std=c99"/>
         <property key="gcc-output-file-format" value="dwarf-3"/>
-        <property key="mapped-progmem" value="false"/>
         <property key="omit-pack-options" value="false"/>
         <property key="omit-pack-options-new" value="3"/>
         <property key="output-file-format" value="-mcof,+elf"/>
-        <property key="smart-io-format" value=""/>
         <property key="stack-size-high" value="auto"/>
         <property key="stack-size-low" value="auto"/>
         <property key="stack-size-main" value="auto"/>

--- a/nbproject/configurations.xml
+++ b/nbproject/configurations.xml
@@ -4,12 +4,6 @@
     <logicalFolder name="HeaderFiles"
                    displayName="Header Files"
                    projectFiles="true">
-      <logicalFolder name="mcc_generated_files"
-                     displayName="mcc_generated_files"
-                     projectFiles="true">
-        <itemPath>mcc_generated_files/adcc.h</itemPath>
-        <itemPath>mcc_generated_files/fvr.h</itemPath>
-      </logicalFolder>
       <logicalFolder name="canlib" displayName="canlib" projectFiles="true">
         <logicalFolder name="pic18f26k83" displayName="pic18f26k83" projectFiles="true">
           <itemPath>canlib/pic18f26k83/pic18f26k83_timer.h</itemPath>
@@ -26,6 +20,12 @@
         <itemPath>canlib/can.h</itemPath>
         <itemPath>canlib/canlib.h</itemPath>
       </logicalFolder>
+      <logicalFolder name="mcc_generated_files"
+                     displayName="mcc_generated_files"
+                     projectFiles="true">
+        <itemPath>mcc_generated_files/adcc.h</itemPath>
+        <itemPath>mcc_generated_files/fvr.h</itemPath>
+      </logicalFolder>
       <itemPath>device_config.h</itemPath>
       <itemPath>platform.h</itemPath>
     </logicalFolder>
@@ -36,12 +36,6 @@
     <logicalFolder name="SourceFiles"
                    displayName="Source Files"
                    projectFiles="true">
-      <logicalFolder name="mcc_generated_files"
-                     displayName="mcc_generated_files"
-                     projectFiles="true">
-        <itemPath>mcc_generated_files/fvr.c</itemPath>
-        <itemPath>mcc_generated_files/adcc.c</itemPath>
-      </logicalFolder>
       <logicalFolder name="canlib" displayName="canlib" projectFiles="true">
         <logicalFolder name="pic18f26k83" displayName="pic18f26k83" projectFiles="true">
           <itemPath>canlib/pic18f26k83/pic18f26k83_can.c</itemPath>
@@ -54,6 +48,12 @@
           <itemPath>canlib/util/safe_ring_buffer.c</itemPath>
         </logicalFolder>
         <itemPath>canlib/can_common.c</itemPath>
+      </logicalFolder>
+      <logicalFolder name="mcc_generated_files"
+                     displayName="mcc_generated_files"
+                     projectFiles="true">
+        <itemPath>mcc_generated_files/fvr.c</itemPath>
+        <itemPath>mcc_generated_files/adcc.c</itemPath>
       </logicalFolder>
       <itemPath>main.c</itemPath>
       <itemPath>device_config.c</itemPath>
@@ -212,7 +212,7 @@
                   value="${memories.instruction.ram.ranges}"/>
         <property key="memories.programmemory" value="true"/>
         <property key="memories.programmemory.ranges" value="0-ffff"/>
-        <property key="poweroptions.powerenable" value="false"/>
+        <property key="poweroptions.powerenable" value="true"/>
         <property key="programmertogo.imagename" value=""/>
         <property key="programoptions.donoteraseauxmem" value="false"/>
         <property key="programoptions.eraseb4program" value="true"/>
@@ -230,7 +230,7 @@
         <property key="programoptions.testmodeentrymethod" value="VDDFirst"/>
         <property key="programoptions.usehighvoltageonmclr" value="false"/>
         <property key="programoptions.uselvpprogramming" value="false"/>
-        <property key="voltagevalue" value="5.0"/>
+        <property key="voltagevalue" value="4.75"/>
       </PICkit3PlatformTool>
       <Tool>
         <property key="AutoSelectMemRanges" value="auto"/>
@@ -256,7 +256,7 @@
                   value="${memories.instruction.ram.ranges}"/>
         <property key="memories.programmemory" value="true"/>
         <property key="memories.programmemory.ranges" value="0-ffff"/>
-        <property key="poweroptions.powerenable" value="false"/>
+        <property key="poweroptions.powerenable" value="true"/>
         <property key="programmertogo.imagename" value=""/>
         <property key="programoptions.donoteraseauxmem" value="false"/>
         <property key="programoptions.eraseb4program" value="true"/>
@@ -274,7 +274,7 @@
         <property key="programoptions.testmodeentrymethod" value="VDDFirst"/>
         <property key="programoptions.usehighvoltageonmclr" value="false"/>
         <property key="programoptions.uselvpprogramming" value="false"/>
-        <property key="voltagevalue" value="5.0"/>
+        <property key="voltagevalue" value="4.75"/>
       </Tool>
       <XC8-CO>
         <property key="coverage-enable" value=""/>

--- a/nbproject/configurations.xml
+++ b/nbproject/configurations.xml
@@ -213,7 +213,7 @@
                   value="${memories.instruction.ram.ranges}"/>
         <property key="memories.programmemory" value="true"/>
         <property key="memories.programmemory.ranges" value="0-ffff"/>
-        <property key="poweroptions.powerenable" value="true"/>
+        <property key="poweroptions.powerenable" value="false"/>
         <property key="programmertogo.imagename" value=""/>
         <property key="programoptions.donoteraseauxmem" value="false"/>
         <property key="programoptions.eraseb4program" value="true"/>
@@ -243,6 +243,7 @@
         <property key="debugoptions.debug-startup" value="Use system settings"/>
         <property key="debugoptions.reset-behaviour" value="Use system settings"/>
         <property key="debugoptions.useswbreakpoints" value="false"/>
+        <property key="firmware.download.all" value="false"/>
         <property key="hwtoolclock.frcindebug" value="false"/>
         <property key="memories.aux" value="false"/>
         <property key="memories.bootflash" value="true"/>
@@ -257,7 +258,7 @@
                   value="${memories.instruction.ram.ranges}"/>
         <property key="memories.programmemory" value="true"/>
         <property key="memories.programmemory.ranges" value="0-ffff"/>
-        <property key="poweroptions.powerenable" value="true"/>
+        <property key="poweroptions.powerenable" value="false"/>
         <property key="programmertogo.imagename" value=""/>
         <property key="programoptions.donoteraseauxmem" value="false"/>
         <property key="programoptions.eraseb4program" value="true"/>

--- a/nbproject/configurations.xml
+++ b/nbproject/configurations.xml
@@ -1,32 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configurationDescriptor version="65">
   <logicalFolder name="root" displayName="root" projectFiles="true">
-    <logicalFolder name="canlib" displayName="canlib" projectFiles="true">
-      <logicalFolder name="pic18f26k83" displayName="pic18f26k83" projectFiles="true">
-        <itemPath>canlib/pic18f26k83/pic18f26k83_can.c</itemPath>
-        <itemPath>canlib/pic18f26k83/pic18f26k83_timer.h</itemPath>
-        <itemPath>canlib/pic18f26k83/pic18f26k83_timer.c</itemPath>
-        <itemPath>canlib/pic18f26k83/pic18f26k83_can.h</itemPath>
-      </logicalFolder>
-      <logicalFolder name="util" displayName="util" projectFiles="true">
-        <itemPath>canlib/util/can_tx_buffer.c</itemPath>
-        <itemPath>canlib/util/can_rcv_buffer.c</itemPath>
-        <itemPath>canlib/util/timing_util.c</itemPath>
-        <itemPath>canlib/util/timing_util.h</itemPath>
-        <itemPath>canlib/util/can_tx_buffer.h</itemPath>
-        <itemPath>canlib/util/safe_ring_buffer.c</itemPath>
-        <itemPath>canlib/util/can_rcv_buffer.h</itemPath>
-        <itemPath>canlib/util/safe_ring_buffer.h</itemPath>
-      </logicalFolder>
-      <itemPath>canlib/message_types.h</itemPath>
-      <itemPath>canlib/can_common.h</itemPath>
-      <itemPath>canlib/can.h</itemPath>
-      <itemPath>canlib/can_common.c</itemPath>
-      <itemPath>canlib/canlib.h</itemPath>
-    </logicalFolder>
     <logicalFolder name="HeaderFiles"
                    displayName="Header Files"
                    projectFiles="true">
+      <logicalFolder name="mcc_generated_files"
+                     displayName="mcc_generated_files"
+                     projectFiles="true">
+        <itemPath>mcc_generated_files/adcc.h</itemPath>
+        <itemPath>mcc_generated_files/fvr.h</itemPath>
+      </logicalFolder>
+      <logicalFolder name="canlib" displayName="canlib" projectFiles="true">
+        <logicalFolder name="pic18f26k83" displayName="pic18f26k83" projectFiles="true">
+          <itemPath>canlib/pic18f26k83/pic18f26k83_timer.h</itemPath>
+          <itemPath>canlib/pic18f26k83/pic18f26k83_can.h</itemPath>
+        </logicalFolder>
+        <logicalFolder name="util" displayName="util" projectFiles="true">
+          <itemPath>canlib/util/timing_util.h</itemPath>
+          <itemPath>canlib/util/can_tx_buffer.h</itemPath>
+          <itemPath>canlib/util/can_rcv_buffer.h</itemPath>
+          <itemPath>canlib/util/safe_ring_buffer.h</itemPath>
+        </logicalFolder>
+        <itemPath>canlib/message_types.h</itemPath>
+        <itemPath>canlib/can_common.h</itemPath>
+        <itemPath>canlib/can.h</itemPath>
+        <itemPath>canlib/canlib.h</itemPath>
+      </logicalFolder>
       <itemPath>device_config.h</itemPath>
       <itemPath>platform.h</itemPath>
     </logicalFolder>
@@ -37,6 +36,25 @@
     <logicalFolder name="SourceFiles"
                    displayName="Source Files"
                    projectFiles="true">
+      <logicalFolder name="mcc_generated_files"
+                     displayName="mcc_generated_files"
+                     projectFiles="true">
+        <itemPath>mcc_generated_files/fvr.c</itemPath>
+        <itemPath>mcc_generated_files/adcc.c</itemPath>
+      </logicalFolder>
+      <logicalFolder name="canlib" displayName="canlib" projectFiles="true">
+        <logicalFolder name="pic18f26k83" displayName="pic18f26k83" projectFiles="true">
+          <itemPath>canlib/pic18f26k83/pic18f26k83_can.c</itemPath>
+          <itemPath>canlib/pic18f26k83/pic18f26k83_timer.c</itemPath>
+        </logicalFolder>
+        <logicalFolder name="util" displayName="util" projectFiles="true">
+          <itemPath>canlib/util/can_tx_buffer.c</itemPath>
+          <itemPath>canlib/util/can_rcv_buffer.c</itemPath>
+          <itemPath>canlib/util/timing_util.c</itemPath>
+          <itemPath>canlib/util/safe_ring_buffer.c</itemPath>
+        </logicalFolder>
+        <itemPath>canlib/can_common.c</itemPath>
+      </logicalFolder>
       <itemPath>main.c</itemPath>
       <itemPath>device_config.c</itemPath>
       <itemPath>platform.c</itemPath>
@@ -47,9 +65,6 @@
       <itemPath>Makefile</itemPath>
     </logicalFolder>
   </logicalFolder>
-  <sourceRootList>
-    <Elem>canlib</Elem>
-  </sourceRootList>
   <projectmakefile>Makefile</projectmakefile>
   <confs>
     <conf name="default" type="2">
@@ -60,8 +75,8 @@
         <targetPluginBoard></targetPluginBoard>
         <platformTool>PICkit3PlatformTool</platformTool>
         <languageToolchain>XC8</languageToolchain>
-        <languageToolchainVersion>2.31</languageToolchainVersion>
-        <platform>2</platform>
+        <languageToolchainVersion>2.41</languageToolchainVersion>
+        <platform>4</platform>
       </toolsSet>
       <packs>
         <pack name="PIC18F-K_DFP" vendor="Microchip" version="1.5.114"/>
@@ -101,7 +116,7 @@
         <property key="default-char-type" value="true"/>
         <property key="define-macros" value="BOARD_UNIQUE_ID=0"/>
         <property key="disable-optimizations" value="true"/>
-        <property key="extra-include-directories" value="canlib"/>
+        <property key="extra-include-directories" value="canlib;mcc_generated_files"/>
         <property key="favor-optimization-for" value="-speed,+space"/>
         <property key="garbage-collect-data" value="true"/>
         <property key="garbage-collect-functions" value="true"/>
@@ -164,7 +179,7 @@
         <property key="input-libraries" value="libm"/>
         <property key="keep-generated-startup.as" value="false"/>
         <property key="link-in-c-library" value="true"/>
-        <property key="link-in-c-library-gcc" value=""/>
+        <property key="link-in-c-library-gcc" value="-mc90lib"/>
         <property key="link-in-peripheral-library" value="false"/>
         <property key="managed-stack" value="false"/>
         <property key="opt-xc8-linker-file" value="false"/>
@@ -267,12 +282,15 @@
       </XC8-CO>
       <XC8-config-global>
         <property key="advanced-elf" value="true"/>
+        <property key="constdata-progmem" value="true"/>
         <property key="gcc-opt-driver-new" value="true"/>
         <property key="gcc-opt-std" value="-std=c99"/>
         <property key="gcc-output-file-format" value="dwarf-3"/>
+        <property key="mapped-progmem" value="false"/>
         <property key="omit-pack-options" value="false"/>
         <property key="omit-pack-options-new" value="3"/>
         <property key="output-file-format" value="-mcof,+elf"/>
+        <property key="smart-io-format" value=""/>
         <property key="stack-size-high" value="auto"/>
         <property key="stack-size-low" value="auto"/>
         <property key="stack-size-main" value="auto"/>

--- a/nbproject/configurations.xml
+++ b/nbproject/configurations.xml
@@ -28,6 +28,7 @@
       </logicalFolder>
       <itemPath>device_config.h</itemPath>
       <itemPath>platform.h</itemPath>
+      <itemPath>error_checks.h</itemPath>
     </logicalFolder>
     <logicalFolder name="LinkerScript"
                    displayName="Linker Files"
@@ -58,6 +59,7 @@
       <itemPath>main.c</itemPath>
       <itemPath>device_config.c</itemPath>
       <itemPath>platform.c</itemPath>
+      <itemPath>error_checks.c</itemPath>
     </logicalFolder>
     <logicalFolder name="ExternalFiles"
                    displayName="Important Files"

--- a/nbproject/project.xml
+++ b/nbproject/project.xml
@@ -12,10 +12,7 @@
             <asminc-extensions/>
             <sourceEncoding>ISO-8859-1</sourceEncoding>
             <make-dep-projects/>
-            <sourceRootList>
-                <sourceRootElem>canlib</sourceRootElem>
-                <sourceRootElem>mcc_generated_files</sourceRootElem>
-            </sourceRootList>
+            <sourceRootList/>
             <confList>
                 <confElem>
                     <name>default</name>

--- a/nbproject/project.xml
+++ b/nbproject/project.xml
@@ -3,7 +3,7 @@
     <type>com.microchip.mplab.nbide.embedded.makeproject</type>
     <configuration>
         <data xmlns="http://www.netbeans.org/ns/make-project/1">
-            <name>cansw_charging</name>
+            <name>cansw_template</name>
             <creation-uuid>a594f85b-6438-49f9-ad57-e3d1d5e4a4c5</creation-uuid>
             <make-project-type>0</make-project-type>
             <c-extensions>c</c-extensions>
@@ -12,7 +12,9 @@
             <asminc-extensions/>
             <sourceEncoding>ISO-8859-1</sourceEncoding>
             <make-dep-projects/>
-            <sourceRootList/>
+            <sourceRootList>
+                <sourceRootElem>canlib</sourceRootElem>
+            </sourceRootList>
             <confList>
                 <confElem>
                     <name>default</name>

--- a/nbproject/project.xml
+++ b/nbproject/project.xml
@@ -3,7 +3,7 @@
     <type>com.microchip.mplab.nbide.embedded.makeproject</type>
     <configuration>
         <data xmlns="http://www.netbeans.org/ns/make-project/1">
-            <name>cansw_template</name>
+            <name>cansw_charging</name>
             <creation-uuid>a594f85b-6438-49f9-ad57-e3d1d5e4a4c5</creation-uuid>
             <make-project-type>0</make-project-type>
             <c-extensions>c</c-extensions>

--- a/nbproject/project.xml
+++ b/nbproject/project.xml
@@ -14,6 +14,7 @@
             <make-dep-projects/>
             <sourceRootList>
                 <sourceRootElem>canlib</sourceRootElem>
+                <sourceRootElem>mcc_generated_files</sourceRootElem>
             </sourceRootList>
             <confList>
                 <confElem>

--- a/platform.c
+++ b/platform.c
@@ -29,6 +29,7 @@ void pin_init(void) {
     LATA5 = 1; //either 1 or 0 to enable it, not sure which, but should default be on
 
     TRISA4 = 0; // set A4 to be an output for battery output voltage
+    ANSELA4 = 1; //enable analog reading
 
     // VSENSE
     TRISC2 = 1; //set BATT_VSENSE to be output

--- a/platform.c
+++ b/platform.c
@@ -4,16 +4,27 @@
 // whether the leds turn on when the pin is set to high or low
 #define LED_ON 0
 
-void gpio_init(void) {
-    // set as outputs
-    TRISC5 = 0;
-    TRISC6 = 0;
-    TRISC7 = 0;
-    
-    // turn LEDs off
+/*
+    // LEDs
+    TRISC5 = 0; // set C5 as an output for the white LED
+    ANSELC5 = 0; // Enable digital input buffer (Useful for reading the LED state)
+    LATC5 = 1; // turn the white LED off
+*/
+void pin_init(void) {
+    // LEDS
+    TRISC5 = 0; // set C5 as an output for red LED
+    ANSELC5 = 0; // enable digital input buffer (Useful for reading the LED state)
     LATC5 = !LED_ON;
+
+    TRISC6 = 0; // set C6 as an output for blue LED
+    ANSELC6 = 0; // enable digital input buffer (Useful for reading the LED state)
     LATC6 = !LED_ON;
+
+    TRISC7 = 0; // set C7 as an output for white LED
+    ANSELC7 = 0; // enable digital input buffer (Useful for reading the LED state)
     LATC7 = !LED_ON;
+
+    // Battery charger
 }
 
 void RED_LED_SET(bool value) {

--- a/platform.c
+++ b/platform.c
@@ -25,6 +25,17 @@ void pin_init(void) {
     LATC7 = !LED_ON;
 
     // Battery charger
+    TRISA5 = 1; // set A5 as an input to toggle battery charging
+    LATA5 = 1; //either 1 or 0 to enable it, not sure which, but should default be on
+
+    TRISA4 = 0; // set A4 to be an output for battery output voltage
+
+    // VSENSE
+    TRISC2 = 1; //set BATT_VSENSE to be output
+    ANSELC2 = 1; //enable analog reading
+
+    TRISC3 = 1; //set VSW_VSENSE to be output
+    ANSELC3 = 1; //enable analog reading
 }
 
 void RED_LED_SET(bool value) {

--- a/platform.c
+++ b/platform.c
@@ -24,6 +24,16 @@ void pin_init(void) {
     ANSELC7 = 0; // enable digital input buffer (Useful for reading the LED state)
     LATC7 = !LED_ON;
 
+    // Rocket power
+    TRISA2 = 1; // set EN_5V to be an input
+    LATA2 = 1; //not sure if its 1 or 0 to enable, but should be default on
+
+    TRISA1 = 0; // set CURR_5V to be output
+    ANSELA1 = 1; // enable analog reading
+
+    TRISA0 = 0; //set CURR_13V to be output
+    ANSELA0 = 1; // enable analog reading
+
     // Battery charger
     TRISA5 = 1; // set A5 as an input to toggle battery charging
     LATA5 = 1; //either 1 or 0 to enable it, not sure which, but should default be on

--- a/platform.c
+++ b/platform.c
@@ -6,22 +6,22 @@
 
 void gpio_init(void) {
     // set as outputs
-    TRISB0 = 0;
-    TRISB1 = 0;
-    TRISB2 = 0;
+    TRISC5 = 0;
+    TRISC6 = 0;
+    TRISC7 = 0;
     
     // turn LEDs off
-    LATB0 = !LED_ON;
-    LATB1 = !LED_ON;
-    LATB2 = !LED_ON;
+    LATC5 = !LED_ON;
+    LATC6 = !LED_ON;
+    LATC7 = !LED_ON;
 }
 
 void RED_LED_SET(bool value) {
-    LATB0 = !value ^ LED_ON;
+    LATC5 = !value ^ LED_ON;
 }
 void BLUE_LED_SET(bool value) {
-    LATB1 = !value ^ LED_ON;
+    LATC6 = !value ^ LED_ON;
 }
 void WHITE_LED_SET(bool value) {
-    LATB2 = !value ^ LED_ON;
+    LATC7 = !value ^ LED_ON;
 }

--- a/platform.c
+++ b/platform.c
@@ -62,6 +62,10 @@ void CAN_5V_SET(bool value) {
     LATA2 = !value ^ CAN_5V_ON;
 }
 
+void CHARGE_CURR_SET(bool value) {
+    LATA5 = !value ^ CHG_BATT_ON;
+}
+
 // the following code was yoinked from cansw_arming
 
 // zach derived the equation alpha = (Fs*T/5)/ 1 + (Fs*T/5)
@@ -74,11 +78,11 @@ void CAN_5V_SET(bool value) {
 double alpha_low = LOW_PASS_ALPHA(LOW_PASS_RESPONSE_TIME);
 double low_pass_curr = 0;
 void update_batt_curr_low_pass(void){
-    double new_curr_reading = ADCC_GetSingleConversion(channel_POWER_V13) * CURR_13V_SCALAR;
+    double new_curr_reading = ADCC_GetSingleConversion(channel_POWER_V13) / CURR_13V_RESISTOR;
 
     low_pass_curr = alpha_low*low_pass_curr + (1.0 - alpha_low)*new_curr_reading;
 }
 
-double get_batt_curr_low_pass(void){
-    return low_pass_curr;
+uint16_t get_batt_curr_low_pass(void){
+    return (uint16_t)low_pass_curr;
 }

--- a/platform.c
+++ b/platform.c
@@ -3,6 +3,8 @@
 
 // whether the leds turn on when the pin is set to high or low
 #define LED_ON 0
+#define LINE_5V_ON 1 //not sure if these are correct values => powers rest of rocket, should be default on?
+#define BATT_ON 1 //not sure if these are correct values
 
 /*
     // LEDs
@@ -25,20 +27,20 @@ void pin_init(void) {
     LATC7 = !LED_ON;
 
     // Rocket power
-    TRISA2 = 1; // set EN_5V to be an input
-    LATA2 = 1; //not sure if its 1 or 0 to enable, but should be default on
+    TRISA2 = 1; // allow 5V current line to be toggleable (input)
+    LATA2 = LINE_5V_ON;
 
-    TRISA1 = 0; // set CURR_5V to be output
+    TRISA1 = 0; // set 5V current draw to be output
     ANSELA1 = 1; // enable analog reading
 
-    TRISA0 = 0; //set CURR_13V to be output
+    TRISA0 = 0; //set 13V current draw to be output
     ANSELA0 = 1; // enable analog reading
 
     // Battery charger
-    TRISA5 = 1; // set A5 as an input to toggle battery charging
-    LATA5 = 1; //either 1 or 0 to enable it, not sure which, but should default be on
+    TRISA5 = 1; // allow battery charging to be toggleable (input)
+    LATA5 = BATT_ON;
 
-    TRISA4 = 0; // set A4 to be an output for battery output voltage
+    TRISA4 = 0; // set battery charging current to be output
     ANSELA4 = 1; //enable analog reading
 
     // VSENSE
@@ -57,4 +59,7 @@ void BLUE_LED_SET(bool value) {
 }
 void WHITE_LED_SET(bool value) {
     LATC7 = !value ^ LED_ON;
+}
+void LINE_5V_SET(bool value) {
+    LATA2 = !value ^ LINE_5V_ON;
 }

--- a/platform.c
+++ b/platform.c
@@ -60,3 +60,24 @@ void WHITE_LED_SET(bool value) {
 void CAN_5V_SET(bool value) {
     LATA2 = !value ^ CAN_5V_ON;
 }
+
+// the following code was yoinked from cansw_arming
+
+// zach derived the equation alpha = (Fs*T/5)/ 1 + (Fs*T/5)
+// where Fs = sampling frequency and T = response time
+// response time is equivalent to 5*tau or 5/2pi*Fc, where Fc is cutoff frequency
+
+#define SAMPLE_FREQ (1000.0 / MAX_SENSOR_LOOP_TIME_DIFF_ms)
+#define LOW_PASS_ALPHA(TR) ((SAMPLE_FREQ * TR / 5.0) / (1 + SAMPLE_FREQ * TR / 5.0))
+#define LOW_PASS_RESPONSE_TIME 10  //seconds
+double alpha_low = LOW_PASS_ALPHA(LOW_PASS_RESPONSE_TIME);
+double low_pass_curr = 0;
+void update_batt_curr_low_pass(void){
+    double new_curr_reading = ADCC_GetSingleConversion(channel_POWER_V13) * CURR_13V_SCALAR;
+
+    low_pass_curr = alpha_low*low_pass_curr + (1.0 - alpha_low)*new_curr_reading;
+}
+
+double get_batt_curr_low_pass(void){
+    return low_pass_curr;
+}

--- a/platform.c
+++ b/platform.c
@@ -3,7 +3,7 @@
 #include "mcc_generated_files/adcc.h"
 
 // LEDs and switches
-#define LED_ON 0 // TODO: is this correct??
+#define LED_ON 0
 #define CAN_5V_ON 1
 #define CHG_BATT_ON 0
 

--- a/platform.c
+++ b/platform.c
@@ -1,8 +1,9 @@
 #include <xc.h>
 #include "platform.h"
+#include "mcc_generated_files/adcc.h"
 
 // LEDs and switches
-#define LED_ON 0
+#define LED_ON 0 // TODO: is this correct??
 #define CAN_5V_ON 1
 #define CHG_BATT_ON 0
 
@@ -69,7 +70,7 @@ void CAN_5V_SET(bool value) {
 
 #define SAMPLE_FREQ (1000.0 / MAX_SENSOR_LOOP_TIME_DIFF_ms)
 #define LOW_PASS_ALPHA(TR) ((SAMPLE_FREQ * TR / 5.0) / (1 + SAMPLE_FREQ * TR / 5.0))
-#define LOW_PASS_RESPONSE_TIME 10  //seconds
+#define LOW_PASS_RESPONSE_TIME 10 // seconds
 double alpha_low = LOW_PASS_ALPHA(LOW_PASS_RESPONSE_TIME);
 double low_pass_curr = 0;
 void update_batt_curr_low_pass(void){

--- a/platform.c
+++ b/platform.c
@@ -4,7 +4,7 @@
 // whether the leds turn on when the pin is set to high or low
 #define LED_ON 0
 #define LINE_5V_ON 1 //not sure if these are correct values => powers rest of rocket, should be default on?
-#define BATT_ON 1 //not sure if these are correct values
+#define BATT_ON 0 //not sure if these are correct values
 
 /*
     // LEDs

--- a/platform.c
+++ b/platform.c
@@ -27,27 +27,27 @@ void pin_init(void) {
     LATC7 = !LED_ON;
 
     // Rocket power
-    TRISA2 = 1; // allow 5V current line to be toggleable (input)
+    TRISA2 = 0; // allow 5V current line to be toggleable (output)
     LATA2 = LINE_5V_ON;
 
-    TRISA1 = 0; // set 5V current draw to be output
+    TRISA1 = 1; // set 5V current draw to be input
     ANSELA1 = 1; // enable analog reading
 
-    TRISA0 = 0; //set 13V current draw to be output
+    TRISA0 = 1; //set 13V current draw to be input
     ANSELA0 = 1; // enable analog reading
 
     // Battery charger
-    TRISA5 = 1; // allow battery charging to be toggleable (input)
+    TRISA5 = 0; // allow battery charging to be toggleable (output)
     LATA5 = BATT_ON;
 
-    TRISA4 = 0; // set battery charging current to be output
+    TRISA4 = 1; // set battery charging current to be input
     ANSELA4 = 1; //enable analog reading
 
     // VSENSE
-    TRISC2 = 1; //set BATT_VSENSE to be output
+    TRISC2 = 1; //set BATT_VSENSE to be input
     ANSELC2 = 1; //enable analog reading
 
-    TRISC3 = 1; //set VSW_VSENSE to be output
+    TRISC3 = 1; //set VSW_VSENSE to be input
     ANSELC3 = 1; //enable analog reading
 }
 

--- a/platform.c
+++ b/platform.c
@@ -1,9 +1,10 @@
 #include <xc.h>
 #include "platform.h"
 
+// LEDs and switches
 #define LED_ON 0
-#define LINE_5V_ON 1
-#define BATT_ON 0
+#define CAN_5V_ON 1
+#define CHG_BATT_ON 0
 
 void pin_init(void) {
     // LEDS
@@ -21,31 +22,27 @@ void pin_init(void) {
 
     // Rocket power lines
     TRISA2 = 0; // allow 5V current line to be toggle-able
-    LATA2 = LINE_5V_ON;
+    LATA2 = CAN_5V_ON;
 
-    TRISA1 = 1; // set 5V current draw to be input
+    TRISA1 = 1; // set 5V current draw (can 5V bus) to be input
     ANSELA1 = 1; // enable analog reading
 
-    TRISA0 = 1; //set 13V current draw to be input
+    TRISA0 = 1; //set 13V current draw (battery) to be input
     ANSELA0 = 1; // enable analog reading
 
     // Battery charger
     TRISA5 = 0; // allow battery charging to be toggle-able
-    LATA5 = BATT_ON;
+    LATA5 = CHG_BATT_ON;
 
     TRISA4 = 1; // set battery charging current to be input
     ANSELA4 = 1; //enable analog reading
 
     // Voltage health
-    TRISC2 = 1; //set rocket voltage to be input
+    TRISC2 = 1; //set battery voltage to be input
     ANSELC2 = 1; //enable analog reading
 
-    TRISC3 = 1; //set 13V battery voltage to be input
+    TRISC3 = 1; //set rocket voltage to be input
     ANSELC3 = 1; //enable analog reading
-}
-
-void LINE_5V_SET(bool value) {
-    LATA2 = !value ^ LINE_5V_ON;
 }
 
 void RED_LED_SET(bool value) {
@@ -58,4 +55,8 @@ void BLUE_LED_SET(bool value) {
 
 void WHITE_LED_SET(bool value) {
     LATC7 = !value ^ LED_ON;
+}
+
+void CAN_5V_SET(bool value) {
+    LATA2 = !value ^ CAN_5V_ON;
 }

--- a/platform.c
+++ b/platform.c
@@ -1,33 +1,26 @@
-#include "platform.h"
 #include <xc.h>
+#include "platform.h"
 
-// whether the leds turn on when the pin is set to high or low
 #define LED_ON 0
-#define LINE_5V_ON 1 //not sure if these are correct values => powers rest of rocket, should be default on?
-#define BATT_ON 0 //not sure if these are correct values
+#define LINE_5V_ON 1
+#define BATT_ON 0
 
-/*
-    // LEDs
-    TRISC5 = 0; // set C5 as an output for the white LED
-    ANSELC5 = 0; // Enable digital input buffer (Useful for reading the LED state)
-    LATC5 = 1; // turn the white LED off
-*/
 void pin_init(void) {
     // LEDS
-    TRISC5 = 0; // set C5 as an output for red LED
+    TRISC5 = 0; // set red LED pin as output
     ANSELC5 = 0; // enable digital input buffer (Useful for reading the LED state)
     LATC5 = !LED_ON;
 
-    TRISC6 = 0; // set C6 as an output for blue LED
+    TRISC6 = 0; // set blue LED pin as output
     ANSELC6 = 0; // enable digital input buffer (Useful for reading the LED state)
     LATC6 = !LED_ON;
 
-    TRISC7 = 0; // set C7 as an output for white LED
+    TRISC7 = 0; // set white LED pin as output
     ANSELC7 = 0; // enable digital input buffer (Useful for reading the LED state)
     LATC7 = !LED_ON;
 
-    // Rocket power
-    TRISA2 = 0; // allow 5V current line to be toggleable (output)
+    // Rocket power lines
+    TRISA2 = 0; // allow 5V current line to be toggle-able
     LATA2 = LINE_5V_ON;
 
     TRISA1 = 1; // set 5V current draw to be input
@@ -37,29 +30,32 @@ void pin_init(void) {
     ANSELA0 = 1; // enable analog reading
 
     // Battery charger
-    TRISA5 = 0; // allow battery charging to be toggleable (output)
+    TRISA5 = 0; // allow battery charging to be toggle-able
     LATA5 = BATT_ON;
 
     TRISA4 = 1; // set battery charging current to be input
     ANSELA4 = 1; //enable analog reading
 
-    // VSENSE
-    TRISC2 = 1; //set BATT_VSENSE to be input
+    // Voltage health
+    TRISC2 = 1; //set rocket voltage to be input
     ANSELC2 = 1; //enable analog reading
 
-    TRISC3 = 1; //set VSW_VSENSE to be input
+    TRISC3 = 1; //set 13V battery voltage to be input
     ANSELC3 = 1; //enable analog reading
+}
+
+void LINE_5V_SET(bool value) {
+    LATA2 = !value ^ LINE_5V_ON;
 }
 
 void RED_LED_SET(bool value) {
     LATC5 = !value ^ LED_ON;
 }
+
 void BLUE_LED_SET(bool value) {
     LATC6 = !value ^ LED_ON;
 }
+
 void WHITE_LED_SET(bool value) {
     LATC7 = !value ^ LED_ON;
-}
-void LINE_5V_SET(bool value) {
-    LATA2 = !value ^ LINE_5V_ON;
 }

--- a/platform.h
+++ b/platform.h
@@ -3,6 +3,11 @@
 
 #include <stdbool.h>
 
+#define CURR13_DRAW_FACTOR 0.5
+#define BATT_CURR_FACTOR 2
+#define RESISTANCE_DIVIDER_FACTOR 3.2
+
+
 void pin_init(void);
 
 void RED_LED_SET(bool value);

--- a/platform.h
+++ b/platform.h
@@ -4,7 +4,7 @@
 #include <stdbool.h>
 
 // Voltage Monitoring
-#define ANALOG_SCALAR 4.0960 // the magic F constant (?)
+#define RESISTANCE_FACTOR 3.2
 #define SCALE 1.0/1024.0
 
 void pin_init(void);

--- a/platform.h
+++ b/platform.h
@@ -3,10 +3,6 @@
 
 #include <stdbool.h>
 
-// Voltage Monitoring
-#define RESISTANCE_FACTOR 3.2
-#define SCALE 1.0/1024.0
-
 void pin_init(void);
 
 void RED_LED_SET(bool value);

--- a/platform.h
+++ b/platform.h
@@ -3,6 +3,10 @@
 
 #include <stdbool.h>
 
+// Voltage Monitoring
+#define ANALOG_SCALAR 4.0960 // the magic F constant (?)
+#define SCALE 1.0/1024.0
+
 void pin_init(void);
 
 void RED_LED_SET(bool value);

--- a/platform.h
+++ b/platform.h
@@ -14,5 +14,6 @@ void RED_LED_SET(bool value);
 void BLUE_LED_SET(bool value);
 void WHITE_LED_SET(bool value);
 
+void LINE_5V_SET(bool value);
 #endif	/* BOARD_H */
 

--- a/platform.h
+++ b/platform.h
@@ -9,11 +9,12 @@
 #define MAX_SENSOR_LOOP_TIME_DIFF_ms 25
 
 // Voltage monitoring
-#define RESISTANCE_DIVIDER_SCALAR 3.2
+#define BATT_RESISTANCE_DIVIDER 3.2
+#define GROUND_RESISTANCE_DIVIDER 3.2
 // Current monioring
-#define CURR_5V_SCALAR 2.0
-#define CURR_13V_SCALAR 1.0
-#define CHG_CURR_SCALAR 2.0
+#define CURR_5V_RESISTOR 2.0
+#define CURR_13V_RESISTOR 1.0
+#define CHG_CURR_RESISTOR 2.0
 
 void pin_init(void);
 
@@ -22,9 +23,10 @@ void BLUE_LED_SET(bool value);
 void WHITE_LED_SET(bool value);
 
 void CAN_5V_SET(bool value);
+void CHARGE_CURR_SET(bool value);
 
 void update_batt_curr_low_pass(void);
 //returns the value from the lower cut off frequency filter
-double get_batt_curr_low_pass(void);
+uint16_t get_batt_curr_low_pass(void);
 #endif	/* BOARD_H */
 

--- a/platform.h
+++ b/platform.h
@@ -3,10 +3,12 @@
 
 #include <stdbool.h>
 
-#define CUR5_DRAW_FACTOR 1.0
-#define CUR13_DRAW_FACTOR 0.5
-#define BATT_CUR_FACTOR 2
-#define RESISTANCE_DIVIDER_FACTOR 3.2
+// Voltage monitoring
+#define RESISTANCE_DIVIDER_SCALAR 3.2
+// Current monioring
+#define CURR_5V_SCALAR 1.0
+#define CURR_13V_SCALAR 0.5
+#define CHG_CURR_SCALAR 2.0
 
 void pin_init(void);
 
@@ -14,6 +16,6 @@ void RED_LED_SET(bool value);
 void BLUE_LED_SET(bool value);
 void WHITE_LED_SET(bool value);
 
-void LINE_5V_SET(bool value);
+void CAN_5V_SET(bool value);
 #endif	/* BOARD_H */
 

--- a/platform.h
+++ b/platform.h
@@ -3,7 +3,7 @@
 
 #include <stdbool.h>
 
-void gpio_init(void);
+void pin_init(void);
 
 void RED_LED_SET(bool value);
 void BLUE_LED_SET(bool value);

--- a/platform.h
+++ b/platform.h
@@ -3,8 +3,9 @@
 
 #include <stdbool.h>
 
-#define CURR13_DRAW_FACTOR 0.5
-#define BATT_CURR_FACTOR 2
+#define CUR5_DRAW_FACTOR 1.0
+#define CUR13_DRAW_FACTOR 0.5
+#define BATT_CUR_FACTOR 2
 #define RESISTANCE_DIVIDER_FACTOR 3.2
 
 

--- a/platform.h
+++ b/platform.h
@@ -11,8 +11,8 @@
 // Voltage monitoring
 #define RESISTANCE_DIVIDER_SCALAR 3.2
 // Current monioring
-#define CURR_5V_SCALAR 1.0
-#define CURR_13V_SCALAR 0.5
+#define CURR_5V_SCALAR 2.0
+#define CURR_13V_SCALAR 1.0
 #define CHG_CURR_SCALAR 2.0
 
 void pin_init(void);
@@ -23,7 +23,8 @@ void WHITE_LED_SET(bool value);
 
 void CAN_5V_SET(bool value);
 
+void update_batt_curr_low_pass(void);
 //returns the value from the lower cut off frequency filter
-double get_batt_curr_low_low_pass(void);
+double get_batt_curr_low_pass(void);
 #endif	/* BOARD_H */
 

--- a/platform.h
+++ b/platform.h
@@ -3,6 +3,11 @@
 
 #include <stdbool.h>
 
+// Time between main loop code execution
+#define MAX_LOOP_TIME_DIFF_ms 250
+// Time between "high speed" sensor checks
+#define MAX_SENSOR_LOOP_TIME_DIFF_ms 25
+
 // Voltage monitoring
 #define RESISTANCE_DIVIDER_SCALAR 3.2
 // Current monioring
@@ -17,5 +22,8 @@ void BLUE_LED_SET(bool value);
 void WHITE_LED_SET(bool value);
 
 void CAN_5V_SET(bool value);
+
+//returns the value from the lower cut off frequency filter
+double get_batt_curr_low_low_pass(void);
 #endif	/* BOARD_H */
 

--- a/platform.h
+++ b/platform.h
@@ -8,7 +8,6 @@
 #define BATT_CUR_FACTOR 2
 #define RESISTANCE_DIVIDER_FACTOR 3.2
 
-
 void pin_init(void);
 
 void RED_LED_SET(bool value);


### PR DESCRIPTION
Current status:
- Able to read and respond to ```MSG_ACTUATOR_CMD``` CAN messages (toggling the 5V power)
- Able to log necessary info via ```MSG_SENSOR_ANALOG``` CAN messages (values are inline with measured voltage values)

Left to do:
- test the charging capabilities with a lipo (?)
    - this'll also test the ```SENSOR_BUS_CURR```, ```SENSOR_BATT_CURR```, and ```SENSOR_CHARGE_CURR``` values (?)
    
 Testing is planned for the weekend of March 25-26 and until then, this branch will remain dormant

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/cansw_charging/1)
<!-- Reviewable:end -->
