### PR TITLE
overall charging board fixes

### DIFF
--- a/error_checks.c
+++ b/error_checks.c
@@ -38,17 +38,7 @@ bool check_battery_voltage_error(void) {
         // shit's bad yo
         return false;
     }
-    else
-    {
-        can_msg_t batt_volt_msg; // lipo battery voltage
-        build_analog_data_msg(
-            millis(),
-            SENSOR_BATT_VOLT,
-            (uint16_t)(ADCC_GetSingleConversion(channel_BATT_VOLT) * BATT_RESISTANCE_DIVIDER),
-            &batt_volt_msg
-            );
-        txb_enqueue(&batt_volt_msg);
-    }
+
     // things look ok
     return true;
 }

--- a/main.c
+++ b/main.c
@@ -276,7 +276,13 @@ static void can_msg_handler(const can_msg_t *msg) {
             act_state = get_req_actuator_state(msg);
             
             //Battery Charger On/Off
-            if (act_id == ACTUATOR_CHARGE) {
+#if (BOARD_UNIQUE_ID == BOARD_ID_CHARGING_CAN)
+            if (act_id == ACTUATOR_CHARGE_CAN){
+#elif (BOARD_UNIQUE_ID == BOARD_ID_CHARGING_AIRBRAKE)
+            if (act_id == ACTUATOR_CHARGE_AIRBRAKE){
+#elif (BOARD_UNIQUE_ID == BOARD_ID_CHARGING_PAYLOAD)
+            if (act_id == ACTUATOR_CHARGE_PAYLOAD){
+#endif
                 if (act_state == ACTUATOR_ON) {
                     BATTERY_CHARGER_EN(true);
                 } else if (act_state == ACTUATOR_OFF) {

--- a/main.c
+++ b/main.c
@@ -76,6 +76,9 @@ int main(void) {
     
     #if (BOARD_UNIQUE_ID == BOARD_ID_CHARGING_AIRBRAKE || BOARD_UNIQUE_ID == BOARD_ID_CHARGING_PAYLOAD)
     pwm_init();
+    #endif
+
+    #if (BOARD_UNIQUE_ID == BOARD_ID_CHARGING_AIRBRAKE)
     //suspicious lmao
     MOTOR_POWER = MOTOR_ON;
     updatePulseWidth(24);

--- a/main.c
+++ b/main.c
@@ -39,7 +39,7 @@ const uint32_t COAST_LENGTH_MS = 35000-9000;
 volatile bool debug_en = false;
 
 //Commanded extension is 0-100 as % of full extension
-volatile uint8_t cmd_airbrakes_ext = 0;
+volatile uint8_t cmd_airbrakes_ext = 25;
 volatile uint8_t debug_cmd_airbrakes_ext = 0;
 uint8_t curr_airbrakes_ext = 0;
 uint32_t airbrakes_act_time = 0;
@@ -81,7 +81,7 @@ int main(void) {
     #if (BOARD_UNIQUE_ID == BOARD_ID_CHARGING_AIRBRAKE)
     //suspicious lmao
     MOTOR_POWER = MOTOR_ON;
-    updatePulseWidth(24);
+    updatePulseWidth(cmd_airbrakes_ext);
     airbrakes_act_time = millis();
     #endif
 
@@ -230,17 +230,14 @@ int main(void) {
         
         if (state == COAST && ((millis() - inj_open_time) > (BOOST_LENGTH_MS + COAST_LENGTH_MS))) {
             state = DESCENT;
-         
+            cmd_airbrakes_ext = 25;
             MOTOR_POWER = MOTOR_ON;
-            cmd_airbrakes_ext = 0;
             airbrakes_act_time = millis();
         }
         
         //If we are on the ground or in descent, cut motor power after a certain period of time
         if ((state == PRE_FLIGHT || state == DESCENT) 
             && ((millis() - airbrakes_act_time) > MOTOR_ACT_TIME_MS)) {
-            
-            cmd_airbrakes_ext = 24;
             updatePulseWidth(cmd_airbrakes_ext);
             MOTOR_POWER = !MOTOR_ON;
         }

--- a/main.c
+++ b/main.c
@@ -1,5 +1,5 @@
 #include <xc.h>
-#include "canlib.h"
+#include "canlib/canlib.h"
 #include "mcc_generated_files/adcc.h"
 #include "mcc_generated_files/fvr.h"
 #include "device_config.h"
@@ -47,7 +47,7 @@ const uint32_t MOTOR_ACT_TIME_MS = 2000; //Motor guaranteed to fully actuate in 
 
 #elif (BOARD_UNIQUE_ID == BOARD_ID_CHARGING_PAYLOAD)
 volatile bool payload_pump = false;
-const uint8_t PERCENT_SPEED = 50; //percent from 0-100
+const uint8_t PERCENT_SPEED = 20; //percent from 0-100
 #endif
 
 //LEDs: White is heartbeat, Blue is Motor or 5V enable, Red is Battery Charging enable

--- a/main.c
+++ b/main.c
@@ -33,7 +33,8 @@ enum FLIGHT_PHASE {
 };
 
 enum FLIGHT_PHASE state = PRE_FLIGHT;
-const uint32_t BOOST_LENGTH_MS = 9000; // for the purposes of debugging
+const uint32_t BOOST_LENGTH_MS = 9000; 
+const uint32_t COAST_LENGTH_MS = 35000-9000;
 volatile bool debug_en = false;
 
 //Commanded extension is 0-100 as % of full extension
@@ -218,8 +219,17 @@ int main(void) {
             state = COAST;
             MOTOR_POWER = MOTOR_ON;
         }
-        //If we are on the ground, cut motor power after a certain period of time
-        if ((state == PRE_FLIGHT) 
+        
+        if (state == COAST && ((millis() - inj_open_time) > (BOOST_LENGTH_MS + COAST_LENGTH_MS))) {
+            state = DESCENT;
+         
+            MOTOR_POWER = MOTOR_ON;
+            cmd_airbrakes_ext = 0;
+            airbrakes_act_time = millis();
+        }
+        
+        //If we are on the ground or in descent, cut motor power after a certain period of time
+        if ((state == PRE_FLIGHT || state == DESCENT) 
             && ((millis() - airbrakes_act_time) > MOTOR_ACT_TIME_MS)) {
             
             cmd_airbrakes_ext = 0;

--- a/main.c
+++ b/main.c
@@ -1,5 +1,5 @@
 #include <xc.h>
-#include "canlib.h"
+#include "canlib/canlib.h"
 #include "mcc_generated_files/adcc.h"
 #include "mcc_generated_files/fvr.h"
 #include "device_config.h"
@@ -28,9 +28,9 @@ uint32_t inj_open_time = 0;
 
 enum FLIGHT_PHASE {
     PRE_FLIGHT = 0,
-    DESCENT,
     BOOST,
     COAST,
+    DESCENT,
 };
 
 enum FLIGHT_PHASE state = PRE_FLIGHT;

--- a/main.c
+++ b/main.c
@@ -43,7 +43,7 @@ volatile uint8_t cmd_airbrakes_ext = 0;
 volatile uint8_t debug_cmd_airbrakes_ext = 0;
 uint8_t curr_airbrakes_ext = 0;
 uint32_t airbrakes_act_time = 0;
-const uint32_t MOTOR_ACT_TIME_MS = 500; //Motor guaranteed to fully actuate in this time
+const uint32_t MOTOR_ACT_TIME_MS = 2000; //Motor guaranteed to fully actuate in this time
 
 #elif (BOARD_UNIQUE_ID == BOARD_ID_CHARGING_PAYLOAD)
 volatile bool payload_pump = false;
@@ -221,7 +221,6 @@ int main(void) {
             MOTOR_POWER = MOTOR_ON;
         }
         
-        
         //state transition from coast to descent, enable motor for MOTOR_ACT_TIME_MS
         if (state == COAST && ((millis() - inj_open_time) > (BOOST_LENGTH_MS + COAST_LENGTH_MS))) {
             state = DESCENT;
@@ -235,8 +234,9 @@ int main(void) {
         if ((state == PRE_FLIGHT || state == DESCENT) 
             && ((millis() - airbrakes_act_time) > MOTOR_ACT_TIME_MS)) {
             
-            MOTOR_POWER = !MOTOR_ON;
             cmd_airbrakes_ext = 0;
+            updatePulseWidth(cmd_airbrakes_ext);
+            MOTOR_POWER = !MOTOR_ON;
         }
         
         updatePulseWidth(cmd_airbrakes_ext);
@@ -338,6 +338,7 @@ static void can_msg_handler(const can_msg_t *msg) {
                     airbrakes_act_time = millis();
                     cmd_airbrakes_ext = act_state;
                     MOTOR_POWER = MOTOR_ON;
+                    debug_en = false;
                 }
             }
             

--- a/main.c
+++ b/main.c
@@ -308,8 +308,21 @@ static void can_msg_handler(const can_msg_t *msg) {
                     state = BOOST;
                 }
             }
-#endif
-            break;
+//Payload servo command logic
+#elif (BOARD_UNIQUE_ID == BOARD_ID_CHARGING_PAYLOAD)
+            else if (act_id == ACTUATOR_PAYLOAD_SERVO) {
+                if (act_state == ACTUATOR_ON)
+                {
+                    payload_pump = true;
+                }
+                else
+                {
+                    payload_pump = false;
+                }
+            }
+#endif     
+        break;
+        
         case MSG_LEDS_ON:
             RED_LED_SET(true); 
             BLUE_LED_SET(true);
@@ -353,24 +366,7 @@ static void can_msg_handler(const can_msg_t *msg) {
                 debug_en = true;
             }
              break;
-             
-            //Payload servo command logic
-#elif (BOARD_UNIQUE_ID == BOARD_ID_CHARGING_PAYLOAD)
-        case MSG_ACTUATOR_CMD:
-            act_id = get_actuator_id(msg);
-            act_state = get_req_actuator_state(msg);
-            if (act_id == ACTUATOR_PAYLOAD_SERVO) {
-                if (act_state == ACTUATOR_ON)
-                {
-                    payload_pump = true;
-                }
-                else
-                {
-                    payload_pump = false;
-                }
-            }
-            break;
-#endif     
+#endif             
             
         // all the other ones - do nothing
             

--- a/main.c
+++ b/main.c
@@ -28,6 +28,7 @@ uint32_t inj_open_time = 0;
 
 enum FLIGHT_PHASE {
     PRE_FLIGHT = 0,
+    DESCENT,
     BOOST,
     COAST,
 };

--- a/main.c
+++ b/main.c
@@ -30,12 +30,10 @@ enum FLIGHT_PHASE {
     PRE_FLIGHT = 0,
     BOOST,
     COAST,
-    DESCENT,
 };
 
 enum FLIGHT_PHASE state = PRE_FLIGHT;
-const uint32_t BOOST_LENGTH_MS = 1000; // for the purposes of debugging
-const uint32_t COAST_LENGTH_MS = 2000000; // see above
+const uint32_t BOOST_LENGTH_MS = 9000; // for the purposes of debugging
 volatile bool debug_en = false;
 
 //Commanded extension is 0-100 as % of full extension
@@ -220,18 +218,8 @@ int main(void) {
             state = COAST;
             MOTOR_POWER = MOTOR_ON;
         }
-        
-        //state transition from coast to descent, enable motor for MOTOR_ACT_TIME_MS
-        if (state == COAST && ((millis() - inj_open_time) > (BOOST_LENGTH_MS + COAST_LENGTH_MS))) {
-            state = DESCENT;
-         
-            MOTOR_POWER = MOTOR_ON;
-            cmd_airbrakes_ext = 0;
-            airbrakes_act_time = millis();
-        }
-        
-        //If we are on the ground or in descent, cut motor power after a certain period of time
-        if ((state == PRE_FLIGHT || state == DESCENT) 
+        //If we are on the ground, cut motor power after a certain period of time
+        if ((state == PRE_FLIGHT) 
             && ((millis() - airbrakes_act_time) > MOTOR_ACT_TIME_MS)) {
             
             cmd_airbrakes_ext = 0;

--- a/main.c
+++ b/main.c
@@ -80,9 +80,7 @@ int main(void) {
     MOTOR_POWER = MOTOR_ON;
     updatePulseWidth(24);
     airbrakes_act_time = millis();
-    while((millis() - airbrakes_act_time) < MOTOR_ACT_TIME_MS);
-    MOTOR_POWER = !MOTOR_ON;
-#endif
+    #endif
 
     // set up CAN module
     can_timing_t can_setup;
@@ -241,8 +239,6 @@ int main(void) {
             
             cmd_airbrakes_ext = 24;
             updatePulseWidth(cmd_airbrakes_ext);
-            airbrakes_act_time = millis();
-            while((millis() - airbrakes_act_time) < MOTOR_ACT_TIME_MS);
             MOTOR_POWER = !MOTOR_ON;
         }
         

--- a/main.c
+++ b/main.c
@@ -180,7 +180,16 @@ int main(void) {
         
             // Voltage health
             
-            //battery voltage msg is constructed in check_battery_voltage_error if no error
+            //battery voltage
+            can_msg_t batt_volt_msg;
+            build_analog_data_msg(
+                millis(),
+                SENSOR_BATT_VOLT,
+                (uint16_t)(ADCC_GetSingleConversion(channel_BATT_VOLT) * BATT_RESISTANCE_DIVIDER),
+                &batt_volt_msg
+            );
+            result = txb_enqueue(&batt_volt_msg);
+        
             can_msg_t ground_volt_msg; // groundside battery voltage
             build_analog_data_msg(
                 millis(),
@@ -198,12 +207,11 @@ int main(void) {
         if (millis() - sensor_last_millis > MAX_SENSOR_LOOP_TIME_DIFF_ms) {
             sensor_last_millis = millis();
             update_batt_curr_low_pass();
-#if (BOARD_UNIQUE_ID == BOARD_ID_CHARGING_AIRBRAKE || BOARD_UNIQUE_ID == BOARD_ID_CHARGING_PAYLOAD)
+            #if (BOARD_UNIQUE_ID == BOARD_ID_CHARGING_AIRBRAKE || BOARD_UNIQUE_ID == BOARD_ID_CHARGING_PAYLOAD)
             update_motor_curr_low_pass();
-#elif (BOARD_UNIQUE_ID == BOARD_ID_CHARGING_CAN)
+            #endif
             update_5v_curr_low_pass();
-            update_13v_curr_low_pass();
-#endif            
+            update_13v_curr_low_pass();      
         }
 
 #if (BOARD_UNIQUE_ID == BOARD_ID_CHARGING_AIRBRAKE)

--- a/mcc_generated_files/adcc.c
+++ b/mcc_generated_files/adcc.c
@@ -138,12 +138,12 @@ void ADCC_Initialize(void)
     // ADRPT 0; 
     ADRPT = 0x00;
     // ADPCH ANC4; 
-    ADPCH = 0b010100;//x00;
+    ADPCH = 0b111111;//0b010100;//x00;
     //ADPCH = 0x12;
     // ADACQ 0; 
-    ADACQL = 0x00;
+    ADACQL = 0b11111111;
     // ADACQ 0; 
-    ADACQH = 0x00;
+    ADACQH = 0b11111;
     // ADCAP Additional uC disabled; 
     ADCAP = 0x00;
     // ADPRE 0; 
@@ -162,8 +162,8 @@ void ADCC_Initialize(void)
     ADREF = 0x03;
     // ADACT disabled; 
     ADACT = 0x00;
-    // ADCS FOSC/100; 
-    ADCLK = 0x31;
+    // ADCS FOSC/128; 
+    ADCLK = 0b111111;
     // ADGO stop; ADFM right; ADON enabled; ADCS FOSC/ADCLK; ADCONT disabled; 
     ADCON0 = 0x84;
 }

--- a/mcc_generated_files/adcc.h
+++ b/mcc_generated_files/adcc.h
@@ -71,7 +71,7 @@
 
 typedef uint16_t adc_result_t;
 #ifndef int24_t
-typedef signed short long int int24_t;
+//typedef signed long int int24_t;
 #endif
 
 /** ADC Channel Definition

--- a/nbproject/configurations.xml
+++ b/nbproject/configurations.xml
@@ -79,7 +79,7 @@
         <targetDevice>PIC18F26K83</targetDevice>
         <targetHeader></targetHeader>
         <targetPluginBoard></targetPluginBoard>
-        <platformTool>PICkit3PlatformTool</platformTool>
+        <platformTool>noID</platformTool>
         <languageToolchain>XC8</languageToolchain>
         <languageToolchainVersion>2.45</languageToolchainVersion>
         <platform>4</platform>
@@ -120,7 +120,8 @@
         <property key="call-prologues" value="false"/>
         <property key="default-bitfield-type" value="true"/>
         <property key="default-char-type" value="true"/>
-        <property key="define-macros" value="BOARD_UNIQUE_ID=BOARD_ID_CHARGING_CAN"/>
+        <property key="define-macros"
+                  value="BOARD_UNIQUE_ID=BOARD_ID_CHARGING_AIRBRAKE"/>
         <property key="disable-optimizations" value="true"/>
         <property key="extra-include-directories" value="canlib;mcc_generated_files"/>
         <property key="favor-optimization-for" value="-speed,+space"/>

--- a/platform.c
+++ b/platform.c
@@ -1,6 +1,7 @@
 #include <xc.h>
 
 #include "mcc_generated_files/adcc.h"
+#include "canlib/canlib.h"
 #include "platform.h"
 
 void pin_init(void) {

--- a/platform.c
+++ b/platform.c
@@ -115,7 +115,7 @@ uint16_t get_motor_curr_low_pass(void) {
     return (uint16_t)low_pass_curr_motor;
 }    
 #endif
-#if (BOARD_UNIQUE_ID == BOARD_ID_CHARGING_CAN)
+
 void update_13v_curr_low_pass(void) {
     double new_curr_reading = ADCC_GetSingleConversion(channel_POWER_V13) * CONVERSION_ADC_TO_V / CURR_13V_RESISTOR;
     low_pass_curr_13v = alpha_low * low_pass_curr_13v + (1.0 - alpha_low) * new_curr_reading;
@@ -133,4 +133,3 @@ void update_5v_curr_low_pass(void) {
 uint16_t get_5v_curr_low_pass(void) {
     return (uint16_t)low_pass_curr_5v;
 }
-#endif

--- a/platform.c
+++ b/platform.c
@@ -21,7 +21,7 @@ void pin_init(void) {
     #if (BOARD_UNIQUE_ID == BOARD_ID_CHARGING_CAN)
     LATA3 = CAN_5V_ON;
     #elif (BOARD_UNIQUE_ID == BOARD_ID_CHARGING_AIRBRAKE || BOARD_UNIQUE_ID == BOARD_ID_CHARGING_PAYLOAD)
-    LATA3 = CAN_5V_OFF;
+    LATA3 = !CAN_5V_ON;
     #endif
     TRISA3 = 0; // allow 5V current line to be toggle-able
     

--- a/platform.h
+++ b/platform.h
@@ -52,11 +52,10 @@ uint16_t get_batt_curr_low_pass(void);
 #if (BOARD_UNIQUE_ID == BOARD_ID_CHARGING_PAYLOAD || BOARD_UNIQUE_ID == BOARD_ID_CHARGING_AIRBRAKE)
 void update_motor_curr_low_pass(void);
 uint16_t get_motor_curr_low_pass(void);
-#elif (BOARD_UNIQUE_ID == BOARD_ID_CHARGING_CAN)
+#endif
 void update_13v_curr_low_pass(void);
 uint16_t get_13v_curr_low_pass(void);
 void update_5v_curr_low_pass(void);
 uint16_t get_5v_curr_low_pass(void);
-#endif
 
 #endif /* BOARD_H */

--- a/pwm.c
+++ b/pwm.c
@@ -43,8 +43,11 @@ void pwm_init(void){
     //to set the proper register alignment.
     
     #if (BOARD_UNIQUE_ID == BOARD_ID_CHARGING_AIRBRAKE)
-    CCPR3H = 0b00000000;
-    CCPR3L = 0b10111100;
+    uint32_t pulseWidth_us = (uint32_t) (MOTOR_MIN_PULSE_WIDTH_US + ((float)25 / 100.0) * (MOTOR_MAX_PULSE_WIDTH_US - MOTOR_MIN_PULSE_WIDTH_US));
+    uint32_t bitWrite = (uint32_t) ((pulseWidth_us * 48) / 128); //48 is Fosc in MHz, 128 is prescaler
+    //write PW/(Tosc * prescale value)
+    CCPR3L = bitWrite & 0xFF;
+    CCPR3H = (bitWrite >> 8) & 0x03; //honestly not sure abt this either this is like a very rough guess but as long as the servo wiggles its fine
     #elif (BOARD_UNIQUE_ID == BOARD_ID_CHARGING_PAYLOAD)
     CCPR3H = 0b00000010;
     CCPR3L = 0b00110011;


### PR DESCRIPTION
battery voltage now sends regardless of error
payload and airbrakes now send 5v/13v current messages
LEDs now depend on the real state of the charging/5v/motor pins not if the board received can messages
red LED is ALWAYS charging
blue LED is 5v output on charging_can and motor power on the motor boards
battery charging is no longer set false during the initialization sequence in main.c (its redundant as its already initialized off during pin initialization)